### PR TITLE
Fix `python_requires`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ project_urls =
 	Source = https://github.com/sdwilsh/siobrultech-protocols
 
 [options]
-python_requires = >3.7, <4
+python_requires = >=3.7, <4
 packages = find:
 
 [flake8]


### PR DESCRIPTION
This was meant to be 3.7 and greater, but as-written, it is greater than 3.7.