### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7
           - 3.8
           - 3.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
 	Development Status :: 4 - Beta
 	License :: OSI Approved :: MIT License
 	Operating System :: OS Independent
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 project_urls = 
@@ -20,7 +19,7 @@ project_urls =
 	Source = https://github.com/sdwilsh/siobrultech-protocols
 
 [options]
-python_requires = >3.7, <4
+python_requires = >3.8, <4
 packages = find:
 
 [flake8]


### PR DESCRIPTION
In order to support test harness changes for #15, we need to support Python 3.8 and newer.