### PR TITLE
Fix NumericField.max, add wrapping helpers

### DIFF
--- a/siobrultech_protocols/gem/fields.py
+++ b/siobrultech_protocols/gem/fields.py
@@ -57,7 +57,12 @@ class NumericField(Field):
 
     @property
     def max(self) -> int:
-        return 2 ** self.size
+        """The maximum value that can be encoded in this field."""
+        bits = 8 * self.size
+        if self.signed == Sign.Unsigned:
+            return (1 << bits) - 1
+        else:
+            return (1 << (bits - 1)) - 1
 
 
 class FloatingPointField(Field):

--- a/siobrultech_protocols/gem/fields.py
+++ b/siobrultech_protocols/gem/fields.py
@@ -64,6 +64,16 @@ class NumericField(Field):
         else:
             return (1 << (bits - 1)) - 1
 
+    @property
+    def min(self) -> int:
+        """The minimum value that can be encoded in this field."""
+        if self.signed == Sign.Unsigned:
+            return 0
+        else:
+            # Because the sign bit is just lopped off in parsing, this behaves differently
+            # than a 2's complement signed integer would
+            return -self.max
+
 
 class FloatingPointField(Field):
     def __init__(self, size: int, order: ByteOrder, signed: Sign, divisor: float):

--- a/siobrultech_protocols/gem/fields.py
+++ b/siobrultech_protocols/gem/fields.py
@@ -4,10 +4,11 @@ https://www.brultech.com/software/files/downloadSoft/GEM-PKT_Packet_Format_2_1.p
 """
 from abc import ABC, abstractmethod
 from datetime import datetime
-from enum import Enum
+from enum import Enum, unique
 from typing import Any, List
 
 
+@unique
 class ByteOrder(Enum):
     # Big-endian (the name comes from the GEM packet format spec)
     HiToLo = 1
@@ -15,6 +16,7 @@ class ByteOrder(Enum):
     LoToHi = 2
 
 
+@unique
 class Sign(Enum):
     Signed = 1
     Unsigned = 2

--- a/siobrultech_protocols/gem/fields.py
+++ b/siobrultech_protocols/gem/fields.py
@@ -64,16 +64,6 @@ class NumericField(Field):
         else:
             return (1 << (bits - 1)) - 1
 
-    @property
-    def min(self) -> int:
-        """The minimum value that can be encoded in this field."""
-        if self.signed == Sign.Unsigned:
-            return 0
-        else:
-            # Because the sign bit is just lopped off in parsing, this behaves differently
-            # than a 2's complement signed integer would
-            return -self.max
-
 
 class FloatingPointField(Field):
     def __init__(self, size: int, order: ByteOrder, signed: Sign, divisor: float):

--- a/siobrultech_protocols/gem/fields.py
+++ b/siobrultech_protocols/gem/fields.py
@@ -4,7 +4,20 @@ https://www.brultech.com/software/files/downloadSoft/GEM-PKT_Packet_Format_2_1.p
 """
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Callable, List
+from enum import Enum
+from typing import Any, List
+
+
+class ByteOrder(Enum):
+    # Big-endian (the name comes from the GEM packet format spec)
+    HiToLo = 1
+    # Little endian (the name comes from the GEM packet format spec)
+    LoToHi = 2
+
+
+class Sign(Enum):
+    Signed = 1
+    Unsigned = 2
 
 
 class Field(ABC):
@@ -34,12 +47,13 @@ class BytesField(Field):
 
 
 class NumericField(Field):
-    def __init__(self, size: int, order_fn: Callable[[bytes], int]):
+    def __init__(self, size: int, order: ByteOrder, signed: Sign):
         super().__init__(size=size)
-        self.order_fn = order_fn
+        self.order = order
+        self.signed = signed
 
     def read(self, buffer: bytes, offset: int) -> int:
-        return self.order_fn(buffer[offset : offset + self.size])
+        return _parse(buffer[offset : offset + self.size], self.order, self.signed)
 
     @property
     def max(self) -> int:
@@ -47,8 +61,8 @@ class NumericField(Field):
 
 
 class FloatingPointField(Field):
-    def __init__(self, size: int, order_fn: Callable[[bytes], int], divisor: float):
-        self.raw_field = NumericField(size, order_fn)
+    def __init__(self, size: int, order: ByteOrder, signed: Sign, divisor: float):
+        self.raw_field = NumericField(size, order, signed)
         super().__init__(size=self.raw_field.size)
         self.divisor = divisor
 
@@ -85,13 +99,14 @@ class FloatingPointArrayField(ArrayField):
         self,
         num_elems: int,
         size: int,
-        order_fn: Callable[[bytes], int],
+        order: ByteOrder,
+        signed: Sign,
         divisor: float,
     ):
         super().__init__(
             num_elems=num_elems,
             elem_field=FloatingPointField(
-                size=size, order_fn=order_fn, divisor=divisor
+                size=size, order=order, signed=signed, divisor=divisor
             ),
         )
 
@@ -102,9 +117,10 @@ class FloatingPointArrayField(ArrayField):
 class NumericArrayField(ArrayField):
     elem_field: NumericField
 
-    def __init__(self, num_elems: int, size: int, order_fn: Callable[[bytes], int]):
+    def __init__(self, num_elems: int, size: int, order: ByteOrder, signed: Sign):
         super().__init__(
-            num_elems=num_elems, elem_field=NumericField(size=size, order_fn=order_fn)
+            num_elems=num_elems,
+            elem_field=NumericField(size=size, order=order, signed=signed),
         )
 
     def read(self, buffer: bytes, offset: int) -> List[int]:
@@ -115,12 +131,16 @@ class NumericArrayField(ArrayField):
         return self.elem_field.max
 
 
-def hi_to_lo(raw_octets: bytes, signed=False):
+def _parse(
+    raw_octets: bytes, order: ByteOrder = ByteOrder.HiToLo, signed=Sign.Unsigned
+) -> int:
     """Reads the given octets as a big-endian value. The function name comes
     from how such values are described in the packet format spec."""
     octets = list(raw_octets)
     if len(octets) == 0:
         return 0
+    if order == ByteOrder.LoToHi:
+        octets.reverse()
 
     # If this is a signed field (i.e., temperature), the highest-order
     # bit indicates sign. Detect this (and clear the bit so we can
@@ -129,7 +149,7 @@ def hi_to_lo(raw_octets: bytes, signed=False):
     # This isn't documented in the protocol spec, but matches other
     # implementations.
     sign = 1
-    if signed and (octets[0] & 0x80):
+    if signed == Sign.Signed and (octets[0] & 0x80):
         octets[0] &= ~0x80
         sign = -1
 
@@ -137,25 +157,3 @@ def hi_to_lo(raw_octets: bytes, signed=False):
     for octet in octets:
         result = (result << 8) + octet
     return sign * result
-
-
-def lo_to_hi(raw_octets: bytes, signed=False):
-    """Reads the given octets as a little-endian value. The function name comes
-    from how such values are described in the packet format spec."""
-    octets = bytearray(raw_octets)
-    octets.reverse()
-    return hi_to_lo(octets, signed)
-
-
-def hi_to_lo_signed(octets: bytes):
-    """Reads the given octets as a signed big-endian value. The function
-    name comes from how such values are described in the packet format
-    spec."""
-    return hi_to_lo(octets, True)
-
-
-def lo_to_hi_signed(octets: bytes):
-    """Reads the given octets as a signed little-endian value. The
-    function name comes from how such values are described in the
-    packet format spec."""
-    return lo_to_hi(octets, True)

--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -103,9 +103,12 @@ class Packet(object):
     def delta_polarized_watt_seconds(self, index: int, prev: int) -> int:
         field = self.packet_format.fields["polarized_watt_seconds"]
         assert isinstance(field, NumericArrayField)
-        return self._delta_value(
-            field.elem_field, self.polarized_watt_seconds[index], prev
-        )
+        if self.polarized_watt_seconds is not None:
+            return self._delta_value(
+                field.elem_field, self.polarized_watt_seconds[index], prev
+            )
+        else:
+            return 0
 
     def _delta_value(self, field: NumericField, cur: int, prev: int) -> int:
         if prev > cur:

--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -87,29 +87,37 @@ class Packet(object):
     def num_channels(self):
         return self.packet_format.num_channels
 
-    @property
-    def max_seconds(self):
-        assert isinstance(self.packet_format.fields["seconds"], NumericField)
-        return self.packet_format.fields["seconds"].max
+    def delta_seconds(self, prev: int) -> int:
+        field = self.packet_format.fields["seconds"]
+        assert isinstance(field, NumericField)
+        return self._delta_value(field, self.seconds, prev)
 
-    @property
-    def max_pulse_count(self):
-        assert isinstance(self.packet_format.fields["pulse_counts"], NumericArrayField)
-        return self.packet_format.fields["pulse_counts"].elem_field.max
+    def delta_pulse_count(self, index: int, prev: int) -> int:
+        field = self.packet_format.fields["pulse_counts"]
+        assert isinstance(field, NumericArrayField)
+        return self._delta_value(field.elem_field, self.pulse_counts[index], prev)
 
-    @property
-    def max_absolute_watt_seconds(self):
-        assert isinstance(
-            self.packet_format.fields["absolute_watt_seconds"], NumericArrayField
+    def delta_absolute_watt_seconds(self, index: int, prev: int) -> int:
+        field = self.packet_format.fields["absolute_watt_seconds"]
+        assert isinstance(field, NumericArrayField)
+        return self._delta_value(
+            field.elem_field, self.absolute_watt_seconds[index], prev
         )
-        return self.packet_format.fields["absolute_watt_seconds"].elem_field.max
 
-    @property
-    def max_polarized_watt_seconds(self):
-        assert isinstance(
-            self.packet_format.fields["polarized_watt_seconds"], NumericArrayField
+    def delta_polarized_watt_seconds(self, index: int, prev: int) -> int:
+        field = self.packet_format.fields["polarized_watt_seconds"]
+        assert isinstance(field, NumericArrayField)
+        return self._delta_value(
+            field.elem_field, self.polarized_watt_seconds[index], prev
         )
-        return self.packet_format.fields["polarized_watt_seconds"].elem_field.max
+
+    def _delta_value(self, field: NumericField, cur: int, prev: int) -> int:
+        if prev > cur:
+            diff = field.max + 1 - prev
+            diff += cur
+        else:
+            diff = cur - prev
+        return diff
 
 
 class PacketFormat(object):

--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 
 from .fields import (
     ByteField,
+    ByteOrder,
     BytesField,
     DateTimeField,
     Field,
@@ -19,9 +20,7 @@ from .fields import (
     FloatingPointField,
     NumericArrayField,
     NumericField,
-    hi_to_lo,
-    lo_to_hi,
-    lo_to_hi_signed,
+    Sign,
 )
 
 
@@ -128,36 +127,39 @@ class PacketFormat(object):
         self.num_channels = num_channels
         self.fields: OrderedDict[str, Field] = OrderedDict()
 
-        self.fields["header"] = NumericField(3, hi_to_lo)
-        self.fields["voltage"] = FloatingPointField(2, hi_to_lo, 10.0)
+        self.fields["header"] = NumericField(3, ByteOrder.HiToLo, Sign.Unsigned)
+        self.fields["voltage"] = FloatingPointField(
+            2, ByteOrder.HiToLo, Sign.Unsigned, 10.0
+        )
         self.fields["absolute_watt_seconds"] = NumericArrayField(
-            num_channels, 5, lo_to_hi
+            num_channels, 5, ByteOrder.LoToHi, Sign.Unsigned
         )
         if has_net_metering:
             self.fields["polarized_watt_seconds"] = NumericArrayField(
-                num_channels, 5, lo_to_hi
+                num_channels, 5, ByteOrder.LoToHi, Sign.Unsigned
             )
-        self.fields["serial_number"] = NumericField(2, hi_to_lo)
+        self.fields["serial_number"] = NumericField(2, ByteOrder.HiToLo, Sign.Unsigned)
         self.fields["reserved"] = ByteField()
-        self.fields["device_id"] = NumericField(1, hi_to_lo)
+        self.fields["device_id"] = NumericField(1, ByteOrder.HiToLo, Sign.Unsigned)
         self.fields["currents"] = FloatingPointArrayField(
-            num_channels, 2, lo_to_hi, 50.0
+            num_channels, 2, ByteOrder.LoToHi, Sign.Unsigned, 50.0
         )
-        self.fields["seconds"] = NumericField(3, lo_to_hi)
+        self.fields["seconds"] = NumericField(3, ByteOrder.LoToHi, Sign.Unsigned)
         self.fields["pulse_counts"] = NumericArrayField(
-            PacketFormat.NUM_PULSE_COUNTERS, 3, lo_to_hi
+            PacketFormat.NUM_PULSE_COUNTERS, 3, ByteOrder.LoToHi, Sign.Unsigned
         )
         self.fields["temperatures"] = FloatingPointArrayField(
             PacketFormat.NUM_TEMPERATURE_SENSORS,
             2,
-            lo_to_hi_signed,
+            ByteOrder.LoToHi,
+            Sign.Signed,
             2.0,
         )
         if num_channels == 32:
             self.fields["spare_bytes"] = BytesField(2)
         if has_time_stamp:
             self.fields["time_stamp"] = DateTimeField()
-        self.fields["footer"] = NumericField(2, hi_to_lo)
+        self.fields["footer"] = NumericField(2, ByteOrder.HiToLo, Sign.Unsigned)
         self.fields["checksum"] = ByteField()
 
     @property

--- a/tests/gem/test_fields.py
+++ b/tests/gem/test_fields.py
@@ -1,0 +1,60 @@
+import unittest
+
+from siobrultech_protocols.gem.fields import *
+
+
+class TestFieldParsing(unittest.TestCase):
+    def testByteFieldRead(self):
+        self.assertEqual(b"c", ByteField().read(b"abcdefg", 2))
+
+    def testBytesFieldRead(self):
+        self.assertEqual(b"cdef", BytesField(4).read(b"abcdefg", 2))
+
+    def testNumericFieldHiToLoRead(self):
+        self.assertEqual(1, NumericField(2, hi_to_lo).read(b"\x02\x00\x01", 1))
+
+    def testNumericFieldHiToLoSignedRead(self):
+        self.assertEqual(-1, NumericField(2, hi_to_lo_signed).read(b"\x02\x80\x01", 1))
+
+    def testNumericFieldLoToHiRead(self):
+        self.assertEqual(256, NumericField(2, lo_to_hi).read(b"\x02\x00\x01", 1))
+
+    def testNumericFieldLoToHiSignedRead(self):
+        self.assertEqual(
+            -256, NumericField(2, lo_to_hi_signed).read(b"\x02\x00\x81", 1)
+        )
+
+    def testFloatingPointFieldRead(self):
+        self.assertEqual(
+            0.5, FloatingPointField(2, hi_to_lo, 2.0).read(b"\x02\x00\x01", 1)
+        )
+
+    def testDateTimeFieldRead(self):
+        self.assertEqual(
+            datetime(2020, 1, 1, 0, 0, 0),
+            DateTimeField().read(b"\x02\x14\x01\x01\x00\x00\x00", 1),
+        )
+
+    def testArrayFieldRead(self):
+        self.assertEqual(
+            [1, 2, 3, 4],
+            ArrayField(4, NumericField(2, hi_to_lo)).read(
+                b"\x05\x00\x01\x00\x02\x00\x03\x00\x04", 1
+            ),
+        )
+
+    def testNumericArrayFieldRead(self):
+        self.assertEqual(
+            [1, 2, 3, 4],
+            NumericArrayField(4, 2, hi_to_lo).read(
+                b"\x05\x00\x01\x00\x02\x00\x03\x00\x04", 1
+            ),
+        )
+
+    def testFloatingPointArrayFieldRead(self):
+        self.assertEqual(
+            [0.5, 1.0, 1.5, 2.0],
+            FloatingPointArrayField(4, 2, hi_to_lo, 2.0).read(
+                b"\x05\x00\x01\x00\x02\x00\x03\x00\x04", 1
+            ),
+        )

--- a/tests/gem/test_fields.py
+++ b/tests/gem/test_fields.py
@@ -11,22 +11,33 @@ class TestFieldParsing(unittest.TestCase):
         self.assertEqual(b"cdef", BytesField(4).read(b"abcdefg", 2))
 
     def testNumericFieldHiToLoRead(self):
-        self.assertEqual(1, NumericField(2, hi_to_lo).read(b"\x02\x00\x01", 1))
+        self.assertEqual(
+            1, NumericField(2, ByteOrder.HiToLo, Sign.Unsigned).read(b"\x02\x00\x01", 1)
+        )
 
     def testNumericFieldHiToLoSignedRead(self):
-        self.assertEqual(-1, NumericField(2, hi_to_lo_signed).read(b"\x02\x80\x01", 1))
+        self.assertEqual(
+            -1, NumericField(2, ByteOrder.HiToLo, Sign.Signed).read(b"\x02\x80\x01", 1)
+        )
 
     def testNumericFieldLoToHiRead(self):
-        self.assertEqual(256, NumericField(2, lo_to_hi).read(b"\x02\x00\x01", 1))
+        self.assertEqual(
+            256,
+            NumericField(2, ByteOrder.LoToHi, Sign.Unsigned).read(b"\x02\x00\x01", 1),
+        )
 
     def testNumericFieldLoToHiSignedRead(self):
         self.assertEqual(
-            -256, NumericField(2, lo_to_hi_signed).read(b"\x02\x00\x81", 1)
+            -256,
+            NumericField(2, ByteOrder.LoToHi, Sign.Signed).read(b"\x02\x00\x81", 1),
         )
 
     def testFloatingPointFieldRead(self):
         self.assertEqual(
-            0.5, FloatingPointField(2, hi_to_lo, 2.0).read(b"\x02\x00\x01", 1)
+            0.5,
+            FloatingPointField(2, ByteOrder.HiToLo, Sign.Unsigned, 2.0).read(
+                b"\x02\x00\x01", 1
+            ),
         )
 
     def testDateTimeFieldRead(self):
@@ -38,7 +49,7 @@ class TestFieldParsing(unittest.TestCase):
     def testArrayFieldRead(self):
         self.assertEqual(
             [1, 2, 3, 4],
-            ArrayField(4, NumericField(2, hi_to_lo)).read(
+            ArrayField(4, NumericField(2, ByteOrder.HiToLo, Sign.Unsigned)).read(
                 b"\x05\x00\x01\x00\x02\x00\x03\x00\x04", 1
             ),
         )
@@ -46,7 +57,7 @@ class TestFieldParsing(unittest.TestCase):
     def testNumericArrayFieldRead(self):
         self.assertEqual(
             [1, 2, 3, 4],
-            NumericArrayField(4, 2, hi_to_lo).read(
+            NumericArrayField(4, 2, ByteOrder.HiToLo, Sign.Unsigned).read(
                 b"\x05\x00\x01\x00\x02\x00\x03\x00\x04", 1
             ),
         )
@@ -54,7 +65,7 @@ class TestFieldParsing(unittest.TestCase):
     def testFloatingPointArrayFieldRead(self):
         self.assertEqual(
             [0.5, 1.0, 1.5, 2.0],
-            FloatingPointArrayField(4, 2, hi_to_lo, 2.0).read(
+            FloatingPointArrayField(4, 2, ByteOrder.HiToLo, Sign.Unsigned, 2.0).read(
                 b"\x05\x00\x01\x00\x02\x00\x03\x00\x04", 1
             ),
         )

--- a/tests/gem/test_fields.py
+++ b/tests/gem/test_fields.py
@@ -46,20 +46,6 @@ class TestFieldParsing(unittest.TestCase):
             field.max,
         )
 
-    def testNumericFieldUnsignedMin(self):
-        field = NumericField(2, ByteOrder.HiToLo, Sign.Unsigned)
-        self.assertEqual(
-            0,
-            field.min,
-        )
-
-    def testNumericFieldSignedMin(self):
-        field = NumericField(2, ByteOrder.HiToLo, Sign.Signed)
-        self.assertEqual(
-            field.read(b"\xff\xff", 0),
-            field.min,
-        )
-
     def testFloatingPointFieldRead(self):
         self.assertEqual(
             0.5,

--- a/tests/gem/test_fields.py
+++ b/tests/gem/test_fields.py
@@ -32,6 +32,20 @@ class TestFieldParsing(unittest.TestCase):
             NumericField(2, ByteOrder.LoToHi, Sign.Signed).read(b"\x02\x00\x81", 1),
         )
 
+    def testNumericFieldUnsignedMax(self):
+        field = NumericField(2, ByteOrder.HiToLo, Sign.Unsigned)
+        self.assertEqual(
+            field.read(b"\xff\xff", 0),
+            field.max,
+        )
+
+    def testNumericFieldSignedMax(self):
+        field = NumericField(2, ByteOrder.HiToLo, Sign.Signed)
+        self.assertEqual(
+            field.read(b"\x7f\xff", 0),
+            field.max,
+        )
+
     def testFloatingPointFieldRead(self):
         self.assertEqual(
             0.5,

--- a/tests/gem/test_fields.py
+++ b/tests/gem/test_fields.py
@@ -46,6 +46,20 @@ class TestFieldParsing(unittest.TestCase):
             field.max,
         )
 
+    def testNumericFieldUnsignedMin(self):
+        field = NumericField(2, ByteOrder.HiToLo, Sign.Unsigned)
+        self.assertEqual(
+            0,
+            field.min,
+        )
+
+    def testNumericFieldSignedMin(self):
+        field = NumericField(2, ByteOrder.HiToLo, Sign.Signed)
+        self.assertEqual(
+            field.read(b"\xff\xff", 0),
+            field.min,
+        )
+
     def testFloatingPointFieldRead(self):
         self.assertEqual(
             0.5,

--- a/tests/gem/test_packets.py
+++ b/tests/gem/test_packets.py
@@ -51,6 +51,97 @@ class TestPacketFormats(unittest.TestCase):
         assert_packet("BIN32-NET.bin", packet)
 
 
+class TestPacketDeltaComputation(unittest.TestCase):
+    def test_packet_delta_seconds(self):
+        packet = parse_packet("BIN32-ABS.bin", packets.BIN32_ABS)
+        self.assertEqual(997492, packet.seconds)
+
+        self.assertEqual(997493, packet.delta_seconds(2 ** 24 - 1))
+        self.assertEqual(1000000, packet.delta_seconds(2 ** 24 - (1000000 - 997492)))
+
+    def test_packet_delta_pulses(self):
+        packet = parse_packet("BIN48-NET-TIME_tricky.bin", packets.BIN48_NET_TIME)
+
+        # All the pulse counts in our packets are 0, so let's fake some out
+        packet.pulse_counts = [100, 200, 300, 400]
+
+        self.assertEqual(
+            [1100, 1200, 1300, 1400],
+            [
+                packet.delta_pulse_count(i, 2 ** 24 - 1000)
+                for i in range(0, len(packet.pulse_counts))
+            ],
+        )
+
+    def test_packet_delta_absolute_watt_seconds(self):
+        packet = parse_packet("BIN32-ABS.bin", packets.BIN32_ABS)
+        self.assertEqual(
+            [
+                3123664,
+                9249700,
+                195388151,
+                100917236,
+                7139112,
+                1440,
+                4,
+                3,
+                14645520,
+                111396601,
+                33259670,
+                38296448,
+                1108415,
+                2184858,
+                5191049,
+                1,
+                71032651,
+                60190845,
+                47638292,
+                12017483,
+                36186563,
+                14681918,
+                69832947,
+                37693,
+                60941899,
+                1685614,
+                902,
+                799182,
+                302590,
+                3190972,
+                5,
+                647375119,
+            ],
+            packet.absolute_watt_seconds,
+        )
+
+        self.assertEqual(
+            [
+                packet.absolute_watt_seconds[i] + 1000
+                for i in range(0, len(packet.absolute_watt_seconds))
+            ],
+            [
+                packet.delta_absolute_watt_seconds(i, 2 ** 40 - 1000)
+                for i in range(0, len(packet.absolute_watt_seconds))
+            ],
+        )
+
+    def test_packet_delta_polarized_watt_seconds(self):
+        packet = parse_packet("BIN32-NET.bin", packets.BIN32_NET)
+
+        # Packet didn't have any negative numbers, so let's do some manual ones
+        packet.polarized_watt_seconds = [-1600 + 100 * i for i in range(0, 32)]
+
+        self.assertEqual(
+            [
+                packet.polarized_watt_seconds[i] + 1000 + 2 ** 39
+                for i in range(0, len(packet.polarized_watt_seconds))
+            ],
+            [
+                packet.delta_polarized_watt_seconds(i, 2 ** 39 - 1000)
+                for i in range(0, len(packet.polarized_watt_seconds))
+            ],
+        )
+
+
 def check_packet(packet_file_name, packet_format):
     packet = parse_packet(packet_file_name, packet_format)
 

--- a/tests/gem/test_packets.py
+++ b/tests/gem/test_packets.py
@@ -128,7 +128,9 @@ class TestPacketDeltaComputation(unittest.TestCase):
         packet = parse_packet("BIN32-NET.bin", packets.BIN32_NET)
 
         # Packet didn't have any negative numbers, so let's do some manual ones
-        packet.polarized_watt_seconds = [-1600 + 100 * i for i in range(0, 32)]
+        packet.polarized_watt_seconds = [
+            -1600 + 100 * i for i in range(0, packet.num_channels)
+        ]
 
         self.assertEqual(
             [


### PR DESCRIPTION
I noticed that the wrap computation in `greeneye-monitor` was wrong, and actually so was the max value being reported by the `NumericField` class. This PR adds tests for all the `Field` classes, corrects the logic of `max`, and adds helpers for computing delta values.