### PR TITLE
Expose types to consumers, make more complete

### DIFF
--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -8,7 +8,7 @@ import codecs
 import json
 from collections import OrderedDict
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from .fields import (
     ByteField,
@@ -39,30 +39,28 @@ class Packet(object):
         serial_number: int,
         seconds: int,
         pulse_counts: List[int],
-        temperatures: Optional[int],
+        temperatures: List[float],
         polarized_watt_seconds: Optional[List[int]] = None,
-        currents: Optional[float] = None,
+        currents: Optional[List[float]] = None,
         time_stamp: Optional[datetime] = None,
-        **kwargs
+        **kwargs: Dict[str, Any]
     ):
-        self.packet_format = packet_format
-        self.voltage = voltage
-        self.absolute_watt_seconds = absolute_watt_seconds
-        if polarized_watt_seconds:
-            self.polarized_watt_seconds = polarized_watt_seconds
-        if currents:
-            self.currents = currents
-        self.device_id = device_id
-        self.serial_number = serial_number
-        self.seconds = seconds
-        self.pulse_counts = pulse_counts
-        self.temperatures = temperatures
+        self.packet_format: PacketFormat = packet_format
+        self.voltage: float = voltage
+        self.absolute_watt_seconds: List[int] = absolute_watt_seconds
+        self.polarized_watt_seconds: Optional[List[int]] = polarized_watt_seconds
+        self.currents: Optional[List[float]] = currents
+        self.device_id: int = device_id
+        self.serial_number: int = serial_number
+        self.seconds: int = seconds
+        self.pulse_counts: List[int] = pulse_counts
+        self.temperatures: List[float] = temperatures
         if time_stamp:
-            self.time_stamp = time_stamp
+            self.time_stamp: datetime = time_stamp
         else:
-            self.time_stamp = datetime.now()
+            self.time_stamp: datetime = datetime.now()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return json.dumps(
             {
                 "device_id": self.device_id,
@@ -70,10 +68,8 @@ class Packet(object):
                 "seconds": self.seconds,
                 "voltage": self.voltage,
                 "absolute_watt_seconds": self.absolute_watt_seconds,
-                "polarized_watt_seconds": self.polarized_watt_seconds
-                if hasattr(self, "polarized_watt_seconds")
-                else None,
-                "currents": self.currents if hasattr(self, "currents") else None,
+                "polarized_watt_seconds": self.polarized_watt_seconds,
+                "currents": self.currents,
                 "pulse_counts": self.pulse_counts,
                 "temperatures": self.temperatures,
                 "time_stamp": self.time_stamp.isoformat(),
@@ -81,32 +77,32 @@ class Packet(object):
         )
 
     @property
-    def type(self):
+    def type(self) -> str:
         return self.packet_format.name
 
     @property
-    def num_channels(self):
+    def num_channels(self) -> int:
         return self.packet_format.num_channels
 
     @property
-    def max_seconds(self):
+    def max_seconds(self) -> int:
         assert isinstance(self.packet_format.fields["seconds"], NumericField)
         return self.packet_format.fields["seconds"].max
 
     @property
-    def max_pulse_count(self):
+    def max_pulse_count(self) -> int:
         assert isinstance(self.packet_format.fields["pulse_counts"], NumericArrayField)
         return self.packet_format.fields["pulse_counts"].elem_field.max
 
     @property
-    def max_absolute_watt_seconds(self):
+    def max_absolute_watt_seconds(self) -> int:
         assert isinstance(
             self.packet_format.fields["absolute_watt_seconds"], NumericArrayField
         )
         return self.packet_format.fields["absolute_watt_seconds"].elem_field.max
 
     @property
-    def max_polarized_watt_seconds(self):
+    def max_polarized_watt_seconds(self) -> int:
         assert isinstance(
             self.packet_format.fields["polarized_watt_seconds"], NumericArrayField
         )
@@ -122,10 +118,10 @@ class PacketFormat(object):
         name: str,
         num_channels: int,
         has_net_metering: bool = False,
-        has_time_stamp=False,
+        has_time_stamp: bool = False,
     ):
-        self.name = name
-        self.num_channels = num_channels
+        self.name: str = name
+        self.num_channels: int = num_channels
         self.fields: OrderedDict[str, Field] = OrderedDict()
 
         self.fields["header"] = NumericField(3, hi_to_lo)
@@ -161,7 +157,7 @@ class PacketFormat(object):
         self.fields["checksum"] = ByteField()
 
     @property
-    def size(self):
+    def size(self) -> int:
         result = 0
         for value in self.fields.values():
             result += value.size

--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from .packets import (
     BIN32_ABS,
@@ -23,17 +23,17 @@ class PacketProtocol(asyncio.Protocol):
         self._queue = queue
         self._transport: Optional[asyncio.BaseTransport] = None
 
-    def connection_made(self, transport: asyncio.BaseTransport):
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self._transport = transport
 
-    def connection_lost(self, exc):
+    def connection_lost(self, exc: Optional[Any]) -> None:
         if exc is not None:
             LOG.warning("Connection lost: {}".format(exc))
         else:
             LOG.info("Connection closed")
         self._transport = None
 
-    def data_received(self, data: bytes):
+    def data_received(self, data: bytes) -> None:
         LOG.debug("Received {} bytes".format(len(data)))
         self._buffer.extend(data)
         try:


### PR DESCRIPTION
I was starting to add types in `greeneye-monitor` and realized that `pyright` run locally didn't pick up on type defs from this package. Adding the `py.typed` marker took care of that. Then I corrected a few mis-typed items and filled out the rest of the interface. The one untyped thing is a thing that couldn't be typed in 3.8 without breaking the build.

```
[0] > pyright --verifytypes siobrultech_protocols
npx: installed 1 in 1.766s
Package name: "siobrultech_protocols"
Package directory: "/Users/jkeljo/siobrultech-protocols/siobrultech_protocols"
Path of py.typed file: "/Users/jkeljo/siobrultech-protocols/siobrultech_protocols/py.typed"

Public modules: 5
   siobrultech_protocols
   siobrultech_protocols.gem
   siobrultech_protocols.gem.fields
   siobrultech_protocols.gem.packets
   siobrultech_protocols.gem.protocol

Symbols used in public interface:
siobrultech_protocols.gem.protocol.PacketProtocol.__init__
  /Users/jkeljo/siobrultech-protocols/siobrultech_protocols/gem/protocol.py:21:9 - error: Type of parameter "queue" is partially unknown
    Parameter type is "Queue[Unknown]"
      Type argument 0 has unknown type

Symbols exported by "siobrultech_protocols": 83
  With known type: 81
  With partially unknown type: 2
  Functions without docstring: 24
  Functions without default param: 111
  Classes without docstring: 13

Other symbols referenced but not exported by "siobrultech_protocols": 748
  With known type: 748
  With partially unknown type: 0

Type completeness score: 97.6%

Completed in 1.18sec
```