### PR TITLE
Publish py.typed as part of artifact

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,10 @@ project_urls =
 python_requires = >3.8, <4
 packages = find:
 
+[options.package_data]
+siobrultech_protocols = py.typed
+
 [flake8]
 max-line-length = 88
 max-complexity = 10
 select = E9,F63,F7,F82
-


### PR DESCRIPTION
I realized in later testing that `py.typed` wasn't getting included in the wheel. (I was using `pip install -e` when I first added the file, so I didn't notice.)