### PR TITLE
Provide a better message when the state is not what is expected

### DIFF
--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -161,7 +161,17 @@ class ProtocolState(Enum):
 
 
 class ProtocolStateException(Exception):
-    pass
+    def __init__(
+        self, actual: ProtocolState, expected: ProtocolState, *args: object
+    ) -> None:
+        self._actual = actual
+        self._expected = expected
+        super().__init__(*args)
+
+    def __str__(self) -> str:
+        return (
+            f"Expected state to be {self._expected.name}, but got {self._actual.name}!"
+        )
 
 
 class BidirectionalProtocol(PacketProtocol):
@@ -243,4 +253,4 @@ class BidirectionalProtocol(PacketProtocol):
 
     def _expect_state(self, expected_state: ProtocolState):
         if self._state != expected_state:
-            raise ProtocolStateException()
+            raise ProtocolStateException(actual=self._state, expected=expected_state)


### PR DESCRIPTION
This now provides an error message that looks something like this:
> E           siobrultech_protocols.gem.protocol.ProtocolStateException: Expected state to be RECEIVING_PACKETS, but got SENT_PACKET_DELAY_REQUEST!