### PR TITLE
`end_api_request` should be callable immediately after `begin_api_request`

### DIFF
--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -73,6 +73,12 @@ class TestBidirectionalProtocol(unittest.TestCase):
         self.assertEqual(response, "RESPONSE")
         self.assertNoPacket()
 
+    def testEndAfterBegin(self):
+        """Checks for the case where user-code may fail, and we just call end_api_request
+        after calling begin_api_request."""
+        self._protocol.begin_api_request()
+        self._protocol.end_api_request()
+
     def assertNoPacket(self):
         self.assertTrue(self._queue.empty())
 


### PR DESCRIPTION
In the case of errors, code may not successfully call
`send_api_request`.  In fact, the documentation even states that you
must always call `end_api_request` even if there was an error.