### PR TITLE
Fix API Setting Methods

### DIFF
--- a/siobrultech_protocols/gem/api.py
+++ b/siobrultech_protocols/gem/api.py
@@ -91,15 +91,15 @@ SET_DATE_AND_TIME = ApiCall[datetime, bool](
 )
 SET_PACKET_FORMAT = ApiCall[int, bool](
     formatter=lambda pf: f"{CMD_SET_PACKET_FORMAT}{pf:02}",
-    parser=lambda response: response == "PKT",
+    parser=lambda response: response == "PKT\r\n",
 )
 SET_PACKET_SEND_INTERVAL = ApiCall[int, bool](
     formatter=lambda si: f"{CMD_SET_PACKET_SEND_INTERVAL}{si:03}",
-    parser=lambda response: response == "IVL",
+    parser=lambda response: response == "IVL\r\n",
 )
 SET_SECONDARY_PACKET_FORMAT = ApiCall[int, bool](
     formatter=lambda pf: f"{CMD_SET_SECONDARY_PACKET_FORMAT}{pf:02}",
-    parser=lambda response: response == "PKF",
+    parser=lambda response: response == "PKF\r\n",
 )
 
 

--- a/siobrultech_protocols/gem/api.py
+++ b/siobrultech_protocols/gem/api.py
@@ -86,8 +86,8 @@ async def get_serial_number(protocol: BidirectionalProtocol) -> int:
 
 
 SET_DATE_AND_TIME = ApiCall[datetime, bool](
-    formatter=lambda dt: f"{CMD_SET_DATE_AND_TIME}{dt.strftime('%y,%m,%d,%H,%M,%S')}",
-    parser=lambda response: response == "DTM",
+    formatter=lambda dt: f"{CMD_SET_DATE_AND_TIME}{dt.strftime('%y,%m,%d,%H,%M,%S')}\r",
+    parser=lambda response: response == "DTM\r\n",
 )
 SET_PACKET_FORMAT = ApiCall[int, bool](
     formatter=lambda pf: f"{CMD_SET_PACKET_FORMAT}{pf:02}",

--- a/tests/gem/test_api.py
+++ b/tests/gem/test_api.py
@@ -69,7 +69,7 @@ class TestApi(unittest.TestCase):
             SET_PACKET_FORMAT,
             "^^^SYSPKT02",
             2,
-            "PKT".encode(),
+            "PKT\r\n".encode(),
             True,
         )
 
@@ -78,7 +78,7 @@ class TestApi(unittest.TestCase):
             SET_PACKET_SEND_INTERVAL,
             "^^^SYSIVL042",
             42,
-            "IVL".encode(),
+            "IVL\r\n".encode(),
             True,
         )
 
@@ -87,7 +87,7 @@ class TestApi(unittest.TestCase):
             SET_SECONDARY_PACKET_FORMAT,
             "^^^SYSPKF00",
             0,
-            "PKF".encode(),
+            "PKF\r\n".encode(),
             True,
         )
 
@@ -187,7 +187,7 @@ class TestApiHelpers(IsolatedAsyncioTestCase):
 
     @pytest.mark.asyncio
     async def test_set_packet_format(self):
-        transport = MockRespondingTransport(self._protocol, "PKT".encode())
+        transport = MockRespondingTransport(self._protocol, "PKT\r\n".encode())
         self._protocol.connection_made(transport)
         success = await set_packet_format(self._protocol, PacketFormatType.BIN32_ABS)
         self.assertTrue(success)
@@ -200,14 +200,14 @@ class TestApiHelpers(IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             await set_packet_send_interval(self._protocol, 257)
 
-        transport = MockRespondingTransport(self._protocol, "IVL".encode())
+        transport = MockRespondingTransport(self._protocol, "IVL\r\n".encode())
         self._protocol.connection_made(transport)
         success = await set_packet_send_interval(self._protocol, 42)
         self.assertTrue(success)
 
     @pytest.mark.asyncio
     async def test_set_secondary_packet_format(self):
-        transport = MockRespondingTransport(self._protocol, "PKF".encode())
+        transport = MockRespondingTransport(self._protocol, "PKF\r\n".encode())
         self._protocol.connection_made(transport)
         success = await set_secondary_packet_format(
             self._protocol, PacketFormatType.BIN32_ABS

--- a/tests/gem/test_api.py
+++ b/tests/gem/test_api.py
@@ -58,9 +58,9 @@ class TestApi(unittest.TestCase):
     def testSetDateTime(self):
         self.assertCall(
             SET_DATE_AND_TIME,
-            "^^^SYSDTM12,08,23,13,30,28",
+            "^^^SYSDTM12,08,23,13,30,28\r",
             datetime.fromisoformat("2012-08-23 13:30:28"),
-            "DTM".encode(),
+            "DTM\r\n".encode(),
             True,
         )
 
@@ -180,7 +180,7 @@ class TestApiHelpers(IsolatedAsyncioTestCase):
 
     @pytest.mark.asyncio
     async def test_set_date_and_time(self):
-        transport = MockRespondingTransport(self._protocol, "DTM".encode())
+        transport = MockRespondingTransport(self._protocol, "DTM\r\n".encode())
         self._protocol.connection_made(transport)
         success = await set_date_and_time(self._protocol, datetime(2020, 3, 11))
         self.assertTrue(success)
@@ -216,7 +216,7 @@ class TestApiHelpers(IsolatedAsyncioTestCase):
 
     @pytest.mark.asyncio
     async def test_synchronize_time(self):
-        transport = MockRespondingTransport(self._protocol, "DTM".encode())
+        transport = MockRespondingTransport(self._protocol, "DTM\r\n".encode())
         self._protocol.connection_made(transport)
         success = await synchronize_time(self._protocol)
         self.assertTrue(success)


### PR DESCRIPTION
While the docs do not say this, setting the packet format, the secondary
packet format, and the send interval respond with a string followed by
\r\n.