### PR TITLE
Enable callers to properly close protocol transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install siobrultech-protocols
 
 ```python
 import functools
-from siobrultech_protocols.gem.protocols import PacketProtocol, PacketProtocolMessageType
+from siobrultech_protocols.gem.protocols import PacketProtocol, PacketReceivedMessage
 
 # Queue to get received packets from.
 queue = asyncio.Queue()
@@ -44,8 +44,7 @@ protocol_factory = functools.partial(PacketProtocol, queue=queue)
 
 # Dequeue and look for packet received messages. (Typically do this in a loop.)
 message = await queue.get()
-if message.type == PacketProtocolMessageType.PacketReceived:
-    assert message.packet
+if isinstance(message, PacketReceivedMessage):
     packet = message.packet
 queue.task_done()
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ message = await queue.get()
 if message.type == PacketProtocolMessageType.PacketReceived:
     assert message.packet
     packet = message.packet
+queue.task_done()
 ```
 
 ### Receiving data packets AND sending API commands

--- a/README.md
+++ b/README.md
@@ -34,13 +34,19 @@ pip install siobrultech-protocols
 
 ```python
 import functools
-from siobrultech_protocols.gem.protocols import PacketProtocol
+from siobrultech_protocols.gem.protocols import PacketProtocol, PacketProtocolMessageType
 
 # Queue to get received packets from.
 queue = asyncio.Queue()
 
 # Pass this Protocol to whatever receives data from the device.
 protocol_factory = functools.partial(PacketProtocol, queue=queue)
+
+# Dequeue and look for packet received messages. (Typically do this in a loop.)
+message = await queue.get()
+if message.type == PacketProtocolMessageType.PacketReceived:
+    assert message.packet
+    packet = message.packet
 ```
 
 ### Receiving data packets AND sending API commands

--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -78,6 +78,7 @@ class PacketProtocol(asyncio.Protocol):
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         LOG.info("%d: Connection opened", id(self))
+        assert self._transport is None
         self._transport = transport
         self._queue.put_nowait(
             PacketProtocolMessage(
@@ -93,6 +94,7 @@ class PacketProtocol(asyncio.Protocol):
             LOG.warning("%d: Connection lost due to exception", id(self), exc_info=exc)
         else:
             LOG.info("%d: Connection closed", id(self))
+        assert self._transport
         self._transport = None
         self._queue.put_nowait(
             PacketProtocolMessage(

--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -54,7 +54,7 @@ class PacketReceivedMessage(PacketProtocolMessage):
 
 @dataclass(frozen=True)
 class ConnectionLostMessage(PacketProtocolMessage):
-    """Message sent when a protocol loses its connection. exc is the exception that caused the connection to drop, if any. This message is not sent when the protocol's close() method is called."""
+    """Message sent when a protocol loses its connection. exc is the exception that caused the connection to drop, if any."""
 
     exc: Optional[BaseException]
 
@@ -86,7 +86,6 @@ class PacketProtocol(asyncio.Protocol):
             LOG.warning("%d: Connection lost due to exception", id(self), exc_info=exc)
         else:
             LOG.info("%d: Connection closed", id(self))
-        assert self._transport
         self._transport = None
         self._queue.put_nowait(ConnectionLostMessage(protocol=self, exc=exc))
 

--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -46,7 +46,7 @@ class PacketProtocolMessageType(Enum):
     ConnectionLost = auto()
 
 
-@dataclass
+@dataclass(frozen=True)
 class PacketProtocolMessage:
     """
     packet - for PacketReceived messages, the packet that was received; otherwise None

--- a/tests/gem/mock_transport.py
+++ b/tests/gem/mock_transport.py
@@ -7,9 +7,13 @@ from siobrultech_protocols.gem.protocol import BidirectionalProtocol
 class MockTransport(asyncio.WriteTransport):
     def __init__(self) -> None:
         self.writes: List[bytes] = []
+        self.closed: bool = False
 
     def write(self, data: bytes) -> None:
         self.writes.append(data)
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class MockRespondingTransport(asyncio.WriteTransport):

--- a/tests/gem/test_api.py
+++ b/tests/gem/test_api.py
@@ -25,7 +25,7 @@ from siobrultech_protocols.gem.api import (
     set_secondary_packet_format,
     synchronize_time,
 )
-from siobrultech_protocols.gem.packets import Packet, PacketFormatType
+from siobrultech_protocols.gem.packets import PacketFormatType
 from siobrultech_protocols.gem.protocol import (
     API_RESPONSE_WAIT_TIME,
     BidirectionalProtocol,
@@ -116,7 +116,7 @@ class TestApi(unittest.TestCase):
 
 class TestContextManager(IsolatedAsyncioTestCase):
     def setUp(self):
-        self._queue: asyncio.Queue[Packet] = asyncio.Queue()
+        self._queue: asyncio.Queue[PacketProtocolMessage] = asyncio.Queue()
         self._transport = MockTransport()
         self._protocol = BidirectionalProtocol(self._queue)
         self._protocol.connection_made(self._transport)

--- a/tests/gem/test_api.py
+++ b/tests/gem/test_api.py
@@ -29,13 +29,14 @@ from siobrultech_protocols.gem.packets import Packet, PacketFormatType
 from siobrultech_protocols.gem.protocol import (
     API_RESPONSE_WAIT_TIME,
     BidirectionalProtocol,
+    PacketProtocolMessage,
 )
 from tests.gem.mock_transport import MockRespondingTransport, MockTransport
 
 
 class TestApi(unittest.TestCase):
     def setUp(self):
-        self._queue: asyncio.Queue[Packet] = asyncio.Queue()
+        self._queue: asyncio.Queue[PacketProtocolMessage] = asyncio.Queue()
         self._transport = MockTransport()
         self._protocol = BidirectionalProtocol(self._queue)
         self._protocol.connection_made(self._transport)

--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -2,7 +2,6 @@ import asyncio
 import unittest
 
 from siobrultech_protocols.gem.const import CMD_DELAY_NEXT_PACKET
-from siobrultech_protocols.gem.packets import Packet
 from siobrultech_protocols.gem.protocol import (
     BidirectionalProtocol,
     PacketProtocolMessage,

--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -5,6 +5,8 @@ from siobrultech_protocols.gem.const import CMD_DELAY_NEXT_PACKET
 from siobrultech_protocols.gem.packets import Packet
 from siobrultech_protocols.gem.protocol import (
     BidirectionalProtocol,
+    PacketProtocolMessage,
+    PacketProtocolMessageType,
     ProtocolStateException,
 )
 from tests.gem.mock_transport import MockTransport
@@ -13,10 +15,30 @@ from tests.gem.packet_test_data import assert_packet, read_packet
 
 class TestBidirectionalProtocol(unittest.TestCase):
     def setUp(self):
-        self._queue: asyncio.Queue[Packet] = asyncio.Queue()
+        self._queue: asyncio.Queue[PacketProtocolMessage] = asyncio.Queue()
         self._transport = MockTransport()
         self._protocol = BidirectionalProtocol(self._queue)
         self._protocol.connection_made(self._transport)
+        message = self._queue.get_nowait()
+        assert message.type == PacketProtocolMessageType.ConnectionMade
+        assert message.protocol is self._protocol
+        assert message.packet is None
+        assert message.exc is None
+
+    def tearDown(self) -> None:
+        exc = Exception("Test")
+        self._protocol.connection_lost(exc=exc)
+        message = self._queue.get_nowait()
+        assert message.type == PacketProtocolMessageType.ConnectionLost
+        assert message.protocol is self._protocol
+        assert message.packet is None
+        assert message.exc is exc
+        self._protocol.close()  # Close after connection_lost is not required, but at least should not crash
+
+    def testClose(self):
+        self._protocol.close()
+
+        assert self._transport.closed
 
     def testBeginApi(self):
         self._protocol.begin_api_request()
@@ -83,8 +105,12 @@ class TestBidirectionalProtocol(unittest.TestCase):
         self.assertTrue(self._queue.empty())
 
     def assertPacket(self, expected_packet: str):
-        packet = self._queue.get_nowait()
-        assert_packet(expected_packet, packet)
+        message = self._queue.get_nowait()
+        assert message.type == PacketProtocolMessageType.PacketReceived
+        assert message.protocol is self._protocol
+        assert message.exc is None
+        assert message.packet
+        assert_packet(expected_packet, message.packet)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`asyncio` wants transports to be closed. However, when the transports are being created by an asyncio `Server` and passed to new `PacketProtocol` or `BidirectionalProtocol` instances, doing that requires the user of this library to do a lot of obnoxious plumbing of their own.

This PR makes it a little bit easier for them in two ways:
- `PacketProtocol` now sends a message to its associated queue when connections are made and lost, which allows the caller to keep track of active protocol instances
- `PacketProtocol` exposes a `close` method that can be used to close an active protocol

This is a breaking change, since previously the queue contained only `Packet` objects, and now it contains `PacketProtocolMessage`s instead.

Fixes #48 