### PR TITLE
Add `get_average_power` and `get_average_pulse_rate` to `Packet`

### DIFF
--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -173,6 +173,15 @@ class Packet(object):
             delta_consumed_watt_seconds - delta_produced_watt_seconds
         ) / elapsed_seconds
 
+    def get_average_pulse_rate(self, index: int, other_packet: Packet) -> float:
+        oldest_packet, newest_packet = self._packets_sorted(self, other_packet)
+        elapsed_seconds = newest_packet.delta_seconds(oldest_packet.seconds)
+
+        return (
+            newest_packet.delta_pulse_count(index, oldest_packet.pulse_counts[index])
+            / elapsed_seconds
+        )
+
 
 @unique
 class PacketFormatType(IntEnum):

--- a/tests/gem/test_packets.py
+++ b/tests/gem/test_packets.py
@@ -199,6 +199,17 @@ class TestPacketAverageComputation(unittest.TestCase):
         self.assertEqual(packet_a.get_average_power(0, packet_b), -1.0)
         self.assertEqual(packet_b.get_average_power(0, packet_a), -1.0)
 
+    def test_pulse_rate(self):
+        packet_a = packet_maker(
+            pulse_counts=[0] * packets.BIN32_ABS.NUM_PULSE_COUNTERS,
+        )
+        packet_b = packet_maker(
+            pulse_counts=[15] * packets.BIN32_ABS.NUM_PULSE_COUNTERS,
+            seconds=10,
+        )
+        self.assertEqual(packet_a.get_average_pulse_rate(0, packet_b), 1.5)
+        self.assertEqual(packet_b.get_average_pulse_rate(0, packet_a), 1.5)
+
 
 def check_packet(packet_file_name: str, packet_format: packets.PacketFormat):
     packet = parse_packet(packet_file_name, packet_format)


### PR DESCRIPTION
As suggested in #44, this adds two new methods to help consumers get the average power and pulse rate between two packets.