### PR TITLE
Document `T` and `R` Types

### DIFF
--- a/siobrultech_protocols/gem/api.py
+++ b/siobrultech_protocols/gem/api.py
@@ -18,7 +18,9 @@ from .const import (
 )
 from .protocol import PACKET_DELAY_CLEAR_TIME, BidirectionalProtocol
 
+# Argument type of an ApiCall.
 T = TypeVar("T")
+# Return type of an ApiCall response parser.
 R = TypeVar("R")
 
 

--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum, unique
-from typing import Any, Optional, Set, TypeVar, Union
+from typing import Any, Optional, Set, Union
 
 from .const import CMD_DELAY_NEXT_PACKET
 from .packets import (
@@ -25,10 +25,6 @@ API_RESPONSE_WAIT_TIME = timedelta(seconds=3)  # Time to wait for an API respons
 PACKET_DELAY_CLEAR_TIME = timedelta(
     seconds=3
 )  # Time to wait after a packet delay request so that GEM can finish sending any pending packets
-
-
-T = TypeVar("T")
-R = TypeVar("R")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
It had been so long since I touched this code I had forgotten what these were for.  After figuring it out again, it seems prudent to document them.

This also removes an old declaration in the `protocol.py` file that is no longer used of both of these.