### PR TITLE
Allow customizing the packet clear time interval used by the library

### DIFF
--- a/siobrultech_protocols/gem/api.py
+++ b/siobrultech_protocols/gem/api.py
@@ -16,7 +16,7 @@ from .const import (
     ESCAPE_SEQUENCE,
     TARGET_SERIAL_NUMBER_PREFIX,
 )
-from .protocol import PACKET_DELAY_CLEAR_TIME, BidirectionalProtocol
+from .protocol import BidirectionalProtocol
 
 # Argument type of an ApiCall.
 T = TypeVar("T")
@@ -166,5 +166,5 @@ async def synchronize_time(
     Synchronizes the clock on the device to the time on the local device, accounting for the
     time waited for packets to clear.
     """
-    time = datetime.now() + PACKET_DELAY_CLEAR_TIME
+    time = datetime.now() + protocol.packet_delay_clear_time
     return await set_date_and_time(protocol, time, serial_number)

--- a/siobrultech_protocols/gem/const.py
+++ b/siobrultech_protocols/gem/const.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 ESCAPE_SEQUENCE = "^^^"
 _SYSTEM_PREFIX = ESCAPE_SEQUENCE + "SYS"
 _REQUEST_PREFIX = ESCAPE_SEQUENCE + "RQS"
@@ -10,3 +12,7 @@ CMD_SET_DATE_AND_TIME = _SYSTEM_PREFIX + "DTM"
 CMD_SET_PACKET_FORMAT = _SYSTEM_PREFIX + "PKT"
 CMD_SET_PACKET_SEND_INTERVAL = _SYSTEM_PREFIX + "IVL"
 CMD_SET_SECONDARY_PACKET_FORMAT = _SYSTEM_PREFIX + "PKF"
+
+PACKET_DELAY_CLEAR_TIME_DEFAULT = timedelta(
+    seconds=3
+)  # Time to wait after a packet delay request so that GEM can finish sending any pending packets

--- a/tests/gem/test_api.py
+++ b/tests/gem/test_api.py
@@ -39,7 +39,9 @@ class TestApi(unittest.TestCase):
     def setUp(self):
         self._queue: asyncio.Queue[PacketProtocolMessage] = asyncio.Queue()
         self._transport = MockTransport()
-        self._protocol = BidirectionalProtocol(self._queue)
+        self._protocol = BidirectionalProtocol(
+            self._queue, packet_delay_clear_time=timedelta(seconds=0)
+        )
         self._protocol.connection_made(self._transport)
 
         # Put the protocol into a state where it's ready for commands
@@ -134,16 +136,14 @@ class TestContextManager(IsolatedAsyncioTestCase):
     def setUp(self):
         self._queue: asyncio.Queue[PacketProtocolMessage] = asyncio.Queue()
         self._transport = MockTransport()
-        self._protocol = BidirectionalProtocol(self._queue)
+        self._protocol = BidirectionalProtocol(
+            self._queue, packet_delay_clear_time=timedelta(seconds=0)
+        )
         self._protocol.connection_made(self._transport)
 
     @pytest.mark.asyncio
     @patch(
         "siobrultech_protocols.gem.protocol.API_RESPONSE_WAIT_TIME",
-        timedelta(seconds=0),
-    )
-    @patch(
-        "siobrultech_protocols.gem.protocol.PACKET_DELAY_CLEAR_TIME",
         timedelta(seconds=0),
     )
     async def testApiCall(self):
@@ -173,7 +173,9 @@ class TestContextManager(IsolatedAsyncioTestCase):
 
 class TestApiHelpers(IsolatedAsyncioTestCase):
     def setUp(self):
-        self._protocol = BidirectionalProtocol(asyncio.Queue())
+        self._protocol = BidirectionalProtocol(
+            asyncio.Queue(), packet_delay_clear_time=timedelta(seconds=0)
+        )
 
         patcher_API_RESPONSE_WAIT_TIME = patch(
             "siobrultech_protocols.gem.protocol.API_RESPONSE_WAIT_TIME",
@@ -181,12 +183,6 @@ class TestApiHelpers(IsolatedAsyncioTestCase):
         )
         patcher_API_RESPONSE_WAIT_TIME.start()
         self.addCleanup(lambda: patcher_API_RESPONSE_WAIT_TIME.stop())
-        patcher_PACKET_DELAY_CLEAR_TIME = patch(
-            "siobrultech_protocols.gem.protocol.PACKET_DELAY_CLEAR_TIME",
-            timedelta(seconds=0),
-        )
-        patcher_PACKET_DELAY_CLEAR_TIME.start()
-        self.addCleanup(lambda: patcher_PACKET_DELAY_CLEAR_TIME.stop())
 
     @pytest.mark.asyncio
     async def test_get_serial_number(self):


### PR DESCRIPTION
This allows passing a new argument to a `BidirectionalProtocol` that lets the user configure the time the protocol will wait before attempting to send a command.

Should help work around the problem discussed in #84

This introduces a breaking change that removes the constant `PACKET_DELAY_CLEAR_TIME` from `siobrultech_protocols.gem.protocol`.  A new constant, `PACKET_DELAY_CLEAR_TIME_DEFAULT` is added to `siobrultech_protocols.gem.const` that is the default value we use if a value is not provided to the `BidirectionalProtocol`.