### PR TITLE
Fix pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,13 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: "5.0.4"
     hooks:
       - id: flake8
         language_version: python3
   - repo: https://github.com/pycqa/isort
-    rev: "5.10.1"
+    rev: "5.12.0"
     hooks:
       - id: isort
         language_version: python3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 black==22.8.0
 flake8==5.0.4
-isort==5.10.1
+isort==5.12.0
 pre-commit==2.20.0
 pytest==7.2.0
 pytest-asyncio==0.20.1


### PR DESCRIPTION
Fix pre-commit configuration
Pre-commit hooks were failing for me. There were two issues:
1. flake8 URL was to gitlab when it should have been github
2. isort needed updating (same issue as https://github.com/home-assistant/core/issues/86892)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sdwilsh/siobrultech-protocols/pull/105).
* #108
* #107
* #106
* __->__ #105