### PR TITLE
Make pulse counters and temperature sensors optional in Packet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,13 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: "5.0.4"
     hooks:
       - id: flake8
         language_version: python3
   - repo: https://github.com/pycqa/isort
-    rev: "5.10.1"
+    rev: "5.12.0"
     hooks:
       - id: isort
         language_version: python3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 black==22.8.0
 flake8==5.0.4
-isort==5.10.1
+isort==5.12.0
 pre-commit==2.20.0
 pytest==7.2.0
 pytest-asyncio==0.20.1

--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -38,8 +38,8 @@ class Packet(object):
         device_id: int,
         serial_number: int,
         seconds: int,
-        pulse_counts: List[int],
-        temperatures: List[float],
+        pulse_counts: Optional[List[int]] = None,
+        temperatures: Optional[List[float]] = None,
         polarized_watt_seconds: Optional[List[int]] = None,
         currents: Optional[List[float]] = None,
         time_stamp: Optional[datetime] = None,
@@ -53,8 +53,8 @@ class Packet(object):
         self.device_id: int = device_id
         self.serial_number: int = serial_number
         self.seconds: int = seconds
-        self.pulse_counts: List[int] = pulse_counts
-        self.temperatures: List[float] = temperatures
+        self.pulse_counts: List[int] = pulse_counts or []
+        self.temperatures: List[float] = temperatures or []
         if time_stamp:
             self.time_stamp: datetime = time_stamp
         else:

--- a/tests/gem/test_packets.py
+++ b/tests/gem/test_packets.py
@@ -12,8 +12,8 @@ packet_maker = functools.partial(
     device_id=123456,
     serial_number=123456,
     seconds=0,
-    pulse_counts=[0] * packets.PacketFormat.NUM_PULSE_COUNTERS,
-    temperatures=[0] * packets.PacketFormat.NUM_TEMPERATURE_SENSORS,
+    pulse_counts=[0] * packets.GEMPacketFormat.NUM_PULSE_COUNTERS,
+    temperatures=[0] * packets.GEMPacketFormat.NUM_TEMPERATURE_SENSORS,
 )
 
 


### PR DESCRIPTION
Make pulse counters and temperature sensors optional in Packet

I'm working towards adding support for ECM-1240, which doesn't have these sensors.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sdwilsh/siobrultech-protocols/pull/107).
* #108
* __->__ #107
* #106
* #105