### PR TITLE
Make the protocol more resilient to devices that ignore API calls.

### DIFF
--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -327,6 +327,7 @@ class BidirectionalProtocol(PacketProtocol):
         self._expect_state(
             {
                 ProtocolState.RECEIVED_API_RESPONSE,
+                ProtocolState.SENT_API_REQUEST,
                 ProtocolState.SENT_PACKET_DELAY_REQUEST,
             }
         )

--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -66,6 +66,18 @@ class TestBidirectionalProtocol(unittest.TestCase):
         self.assertEqual(response, "RESPONSE")
         self.assertPacket("BIN32-ABS.bin")
 
+    def testDeviceIgnoresApi(self):
+        """Tests that the protocol fails appropriately if a device ignores API calls and just keeps sending packets."""
+        self._protocol.begin_api_request()
+        self._protocol.data_received(read_packet("BIN32-ABS.bin"))
+        self._protocol.send_api_request("REQUEST")
+        self._protocol.data_received(read_packet("BIN32-ABS.bin"))
+        with self.assertRaises(UnicodeDecodeError):
+            self._protocol.receive_api_response()
+        self._protocol.end_api_request()
+
+        self.assertPacket("BIN32-ABS.bin")
+
     def testApiCallWithPacketInProgress(self):
         """Tests that the protocol can handle a packet that's partially arrived when it
         requested a packet delay from the GEM."""


### PR DESCRIPTION
Make the protocol more resilient to devices that ignore API calls.

The protocol was getting into an invalid state. This adds a test that
was initially failing, and then fixes the issue.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sdwilsh/siobrultech-protocols/pull/114).
* #116
* #115
* __->__ #114