### PR TITLE
Add packet helpers for ECM aux channels

### DIFF
--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -61,7 +61,7 @@ class Packet(object):
             self.time_stamp: datetime = time_stamp
         else:
             self.time_stamp: datetime = datetime.now()
-        self.aux = aux
+        self.aux: List[int] = aux or []
         self.dc_voltage = dc_voltage
 
     def __str__(self) -> str:
@@ -99,6 +99,11 @@ class Packet(object):
         field = self.packet_format.fields["pulse_counts"]
         assert isinstance(field, NumericArrayField)
         return self._delta_value(field.elem_field, self.pulse_counts[index], prev)
+
+    def delta_aux_count(self, index: int, prev: int) -> int:
+        field = self.packet_format.fields["aux"]
+        assert isinstance(field, NumericArrayField)
+        return self._delta_value(field.elem_field, self.aux[index], prev)
 
     def delta_absolute_watt_seconds(self, index: int, prev: int) -> int:
         field = self.packet_format.fields["absolute_watt_seconds"]
@@ -183,6 +188,15 @@ class Packet(object):
 
         return (
             newest_packet.delta_pulse_count(index, oldest_packet.pulse_counts[index])
+            / elapsed_seconds
+        )
+
+    def get_average_aux_rate_of_change(self, index: int, other_packet: Packet) -> float:
+        oldest_packet, newest_packet = self._packets_sorted(self, other_packet)
+        elapsed_seconds = newest_packet.delta_seconds(oldest_packet.seconds)
+
+        return (
+            newest_packet.delta_aux_count(index, oldest_packet.aux[index])
             / elapsed_seconds
         )
 

--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -327,6 +327,7 @@ class BidirectionalProtocol(PacketProtocol):
         self._expect_state(
             {
                 ProtocolState.RECEIVED_API_RESPONSE,
+                ProtocolState.SENT_API_REQUEST,
                 ProtocolState.SENT_PACKET_DELAY_REQUEST,
             }
         )

--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -66,6 +66,18 @@ class TestBidirectionalProtocol(unittest.TestCase):
         self.assertEqual(response, "RESPONSE")
         self.assertPacket("BIN32-ABS.bin")
 
+    def testDeviceIgnoresApi(self):
+        """Tests that the protocol fails appropriately if a device ignores API calls and just keeps sending packets."""
+        self._protocol.begin_api_request()
+        self._protocol.data_received(read_packet("BIN32-ABS.bin"))
+        self._protocol.send_api_request("REQUEST")
+        self._protocol.data_received(read_packet("BIN32-ABS.bin"))
+        with self.assertRaises(UnicodeDecodeError):
+            self._protocol.receive_api_response()
+        self._protocol.end_api_request()
+
+        self.assertPacket("BIN32-ABS.bin")
+
     def testApiCallWithPacketInProgress(self):
         """Tests that the protocol can handle a packet that's partially arrived when it
         requested a packet delay from the GEM."""


### PR DESCRIPTION
Add packet helpers for ECM aux channels

ECM-1240 has 5 aux channels that can take either pulse counters or CTs;
this adds packet helper for computing deltas and rates of change for those,
similar to what already exist for the CT and pulse counter channels.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sdwilsh/siobrultech-protocols/pull/115).
* #116
* __->__ #115
* #114