### PR TITLE
Don't divide by zero if no time has elapsed between packets

### DIFF
--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -179,16 +179,25 @@ class Packet(object):
         )
 
         return (
-            delta_consumed_watt_seconds - delta_produced_watt_seconds
-        ) / elapsed_seconds
+            (delta_consumed_watt_seconds - delta_produced_watt_seconds)
+            / elapsed_seconds
+            if elapsed_seconds
+            else 0
+        )
 
     def get_average_pulse_rate(self, index: int, other_packet: Packet) -> float:
         oldest_packet, newest_packet = self._packets_sorted(self, other_packet)
         elapsed_seconds = newest_packet.delta_seconds(oldest_packet.seconds)
 
         return (
-            newest_packet.delta_pulse_count(index, oldest_packet.pulse_counts[index])
-            / elapsed_seconds
+            (
+                newest_packet.delta_pulse_count(
+                    index, oldest_packet.pulse_counts[index]
+                )
+                / elapsed_seconds
+            )
+            if elapsed_seconds
+            else 0
         )
 
     def get_average_aux_rate_of_change(self, index: int, other_packet: Packet) -> float:
@@ -196,8 +205,12 @@ class Packet(object):
         elapsed_seconds = newest_packet.delta_seconds(oldest_packet.seconds)
 
         return (
-            newest_packet.delta_aux_count(index, oldest_packet.aux[index])
-            / elapsed_seconds
+            (
+                newest_packet.delta_aux_count(index, oldest_packet.aux[index])
+                / elapsed_seconds
+            )
+            if elapsed_seconds
+            else 0
         )
 
 

--- a/tests/gem/test_packets.py
+++ b/tests/gem/test_packets.py
@@ -170,6 +170,12 @@ class TestPacketDeltaComputation(unittest.TestCase):
 
 
 class TestPacketAverageComputation(unittest.TestCase):
+    def test_packet_average_power_no_time_passed(self):
+        packet_a = packet_maker(
+            absolute_watt_seconds=[10] * packets.BIN32_ABS.num_channels,
+        )
+        self.assertEqual(packet_a.get_average_power(0, packet_a), 0)
+
     def test_packet_average_power(self):
         packet_a = packet_maker(
             absolute_watt_seconds=[10] * packets.BIN32_ABS.num_channels,
@@ -222,6 +228,12 @@ class TestPacketAverageComputation(unittest.TestCase):
         self.assertEqual(packet_a.get_average_pulse_rate(0, packet_b), 1.5)
         self.assertEqual(packet_b.get_average_pulse_rate(0, packet_a), 1.5)
 
+    def test_pulse_rate_no_time_passed(self):
+        packet_a = packet_maker(
+            pulse_counts=[0] * packets.BIN32_ABS.NUM_PULSE_COUNTERS,
+        )
+        self.assertEqual(packet_a.get_average_pulse_rate(0, packet_a), 0)
+
     def test_aux_rate(self):
         packet_a = packet_maker(
             packet_format=packets.ECM_1240, aux=[0] * packets.ECM_1240.num_aux_channels
@@ -233,6 +245,12 @@ class TestPacketAverageComputation(unittest.TestCase):
         )
         self.assertEqual(packet_a.get_average_aux_rate_of_change(0, packet_b), 1.5)
         self.assertEqual(packet_b.get_average_aux_rate_of_change(0, packet_a), 1.5)
+
+    def test_aux_rate_no_time_passed(self):
+        packet_a = packet_maker(
+            packet_format=packets.ECM_1240, aux=[0] * packets.ECM_1240.num_aux_channels
+        )
+        self.assertEqual(packet_a.get_average_aux_rate_of_change(0, packet_a), 0)
 
 
 def check_packet(packet_file_name: str, packet_format: packets.PacketFormat):


### PR DESCRIPTION
Don't divide by zero if no time has elapsed between packets

Just a bit of safety.
