### PR TITLE
Remove PacketProtocol.close()

### DIFF
--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -97,12 +97,6 @@ class PacketProtocol(asyncio.Protocol):
         except Exception:
             LOG.exception("%d: Exception while attempting to parse a packet.", id(self))
 
-    def close(self) -> None:
-        """Closes the underlying transport, if any."""
-        if self._transport:
-            self._transport.close()
-        self._transport = None
-
     def _get_packet(self) -> Optional[Packet]:
         """
         Returns a full packet if available.

--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -32,12 +32,6 @@ class TestBidirectionalProtocol(unittest.TestCase):
             assert isinstance(message, ConnectionLostMessage)
             assert message.protocol is self._protocol
             assert message.exc is exc
-        self._protocol.close()  # Close after connection_lost is not required, but at least should not crash
-
-    def testClose(self):
-        self._protocol.close()
-
-        assert self._transport.closed
 
     def testBeginApi(self):
         self._protocol.begin_api_request()

--- a/tests/gem/test_protocol.py
+++ b/tests/gem/test_protocol.py
@@ -39,12 +39,6 @@ class TestPacketAccumulator(unittest.TestCase):
             assert isinstance(message, ConnectionLostMessage)
             assert message.protocol is self._protocol
             assert message.exc is exc
-        self._protocol.close()  # Close after connection_lost is not required, but at least should not crash
-
-    def testClose(self):
-        self._protocol.close()
-
-        assert self._transport.closed
 
     def test_single_packet(self):
         packet_data = read_packet("BIN32-ABS.bin")


### PR DESCRIPTION
Remove PacketProtocol.close()

I originally put this in with the idea that it was difficult for callers to keep track of transports to close them (#51). That's not really accurate, though. For `asyncio`, `loop.create_connection()` returns the transport, and the server returned by `loop.create_server()` has a `sockets` member that keeps track of all open sockets. This code snippet from `greeneye_monitor` is an example of how to close them upon shutdown:

```
            # Close existing connections
            for socket in self._server.sockets:
                socket.shutdown(socket.SHUT_RDWR)
                socket.close()
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sdwilsh/siobrultech-protocols/pull/120).
* #126
* #125
* #124
* #123
* #122
* #121
* __->__ #120