### PR TITLE
Allow packets to interleave with API responses

### DIFF
--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -97,31 +97,36 @@ class PacketProtocol(asyncio.Protocol):
 
     def _process_buffer(self) -> bool:
         """
-        Attempts to deliver at most one packet to the queue.
+        Attempts to process one chunk of data in the buffer.
+        - If the buffer starts with a complete packet, delivers that packet to the queue and returns True
+        - If the buffer starts with an incomplete packet, returns False
+        - If the buffer starts with data that is not a packet, removes that data from the buffer, passes it
+          to unknown_data_received(), and returns True
 
-        Returns True if another call to _process_buffer might deliver another packet, False if the caller
+        Subclasses override unknown_data_received to process data in the buffer that is not packets (e.g. responses
+        to API calls).
+
+        Returns True if another call to _process_buffer might be able to process more of the buffer, False if the caller
         should wait for more data to be added to the buffer before calling again.
         """
 
         def skip_malformed_packet(msg: str, *args: Any, **kwargs: Any):
+            header_index = self._buffer.find(PACKET_HEADER, 1)
+            end = header_index if header_index != -1 else len(self._buffer)
             LOG.debug(
                 "%d Skipping malformed packet due to " + msg + ". Buffer contents: %s",
                 id(self),
                 *args,
-                self._buffer,
+                self._buffer[0:end],
             )
-            del self._buffer[0 : len(PACKET_HEADER)]
+            del self._buffer[0:end]
 
         header_index = self._buffer.find(PACKET_HEADER)
-        if header_index == -1:
-            LOG.debug(
-                "%d: No header found. Discarding junk data: %s",
-                id(self),
-                self._buffer,
-            )
-            self._buffer.clear()
-            return False
-        del self._buffer[0:header_index]
+        if header_index != 0:
+            end = header_index if header_index != -1 else len(self._buffer)
+            self.unknown_data_received(self._buffer[0:end])
+            del self._buffer[0:end]
+            return len(self._buffer) > 0
 
         if len(self._buffer) < len(PACKET_HEADER) + 1:
             # Not enough length yet
@@ -148,7 +153,7 @@ class PacketProtocol(asyncio.Protocol):
             packet_format = ECM_1220
         else:
             skip_malformed_packet("unknown format code 0x%x", format_code)
-            return False
+            return len(self._buffer) > 0
 
         if len(self._buffer) < packet_format.size:
             # Not enough length yet
@@ -186,6 +191,13 @@ class PacketProtocol(asyncio.Protocol):
             skip_malformed_packet(e.args[0])
 
         return len(self._buffer) > 0
+
+    def unknown_data_received(self, data: bytes) -> None:
+        LOG.debug(
+            "%d: No header found. Discarding junk data: %s",
+            id(self),
+            data,
+        )
 
     def _ensure_transport(self) -> asyncio.BaseTransport:
         if not self._transport:
@@ -254,12 +266,11 @@ class BidirectionalProtocol(PacketProtocol):
     def packet_delay_clear_time(self) -> timedelta:
         return self._packet_delay_clear_time
 
-    def data_received(self, data: bytes) -> None:
+    def unknown_data_received(self, data: bytes) -> None:
         if self._state == ProtocolState.SENT_API_REQUEST:
-            LOG.debug("%d: Received %d bytes", id(self), len(data))
             self._api_buffer.extend(data)
         else:
-            super().data_received(data)
+            super().unknown_data_received(data)
 
     def begin_api_request(self) -> timedelta:
         """
@@ -303,6 +314,8 @@ class BidirectionalProtocol(PacketProtocol):
         """
         self._expect_state(ProtocolState.SENT_API_REQUEST)
 
+        if len(self._api_buffer) == 0:
+            raise TimeoutError()
         response = bytes(self._api_buffer).decode()
         LOG.debug("%d: Received API response: '%s'", id(self), response)
         self._state = ProtocolState.RECEIVED_API_RESPONSE

--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -60,16 +60,33 @@ class TestBidirectionalProtocol(unittest.TestCase):
         self.assertEqual(response, "RESPONSE")
         self.assertPacket("BIN32-ABS.bin")
 
+    def testPacketInterleavingWithApi(self):
+        """Tests that the protocol can handle a packet coming in in the middle of the API response.
+        (I don't know whether this can happen in practice.)"""
+        self._protocol.begin_api_request()
+        self._protocol.data_received(read_packet("BIN32-ABS.bin"))
+        self._protocol.send_api_request("REQUEST")
+        self._protocol.data_received(b"RES")
+        self._protocol.data_received(read_packet("BIN32-ABS.bin"))
+        self._protocol.data_received(b"PONSE")
+        response = self._protocol.receive_api_response()
+        self._protocol.end_api_request()
+
+        self.assertEqual(response, "RESPONSE")
+        self.assertPacket("BIN32-ABS.bin")
+        self.assertPacket("BIN32-ABS.bin")
+
     def testDeviceIgnoresApi(self):
         """Tests that the protocol fails appropriately if a device ignores API calls and just keeps sending packets."""
         self._protocol.begin_api_request()
         self._protocol.data_received(read_packet("BIN32-ABS.bin"))
         self._protocol.send_api_request("REQUEST")
         self._protocol.data_received(read_packet("BIN32-ABS.bin"))
-        with self.assertRaises(UnicodeDecodeError):
+        with self.assertRaises(TimeoutError):
             self._protocol.receive_api_response()
         self._protocol.end_api_request()
 
+        self.assertPacket("BIN32-ABS.bin")
         self.assertPacket("BIN32-ABS.bin")
 
     def testApiCallWithPacketInProgress(self):


### PR DESCRIPTION
Allow packets to interleave with API responses


I'm working towards ECM-1240 API support. One difference between the GEM and ECM APIs is that the ECM API does not have a way to pause packet sends. As a result, we need to be resilient to a packet arriving while an API call is in progress.

Previously, `BidirectionalProtocol` would intercept all incoming data once it had reached the `SENT_API_REQUEST` state (which is after the packet pause request and the subsequent delay). This PR changes it to only intercept data that `PacketProtocol` does not recognize as a packet.

The code assumes that the packets are sent atomically with respect to API responses -- that is, while a packet might interrupt an API response, no API response can interrupt a packet. That's not documented one way or another, but it seems to be true in practice. (I've actually tried *not* sending the packet pause request to the GEM and this code works fine.)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sdwilsh/siobrultech-protocols/pull/122).
* #126
* #125
* #124
* #123
* __->__ #122