### PR TITLE
Enable packet delay to be skipped

### DIFF
--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -305,6 +305,7 @@ class BidirectionalProtocol(PacketProtocol):
         self,
         queue: asyncio.Queue[PacketProtocolMessage],
         packet_delay_clear_time: timedelta = PACKET_DELAY_CLEAR_TIME_DEFAULT,
+        send_packet_delay: bool = True,
     ):
         # Ensure that the clear time and the response wait time fit within the 15 second packet delay interval that is requested.
         assert (packet_delay_clear_time + API_RESPONSE_WAIT_TIME) < timedelta(
@@ -313,6 +314,7 @@ class BidirectionalProtocol(PacketProtocol):
 
         super().__init__(queue)
         self._api_buffer = bytearray()
+        self.send_packet_delay = send_packet_delay
         self._packet_delay_clear_time = packet_delay_clear_time
         self._state = ProtocolState.RECEIVING_PACKETS
         self._api_call: ApiCall[Any, Any] | None = None
@@ -346,13 +348,15 @@ class BidirectionalProtocol(PacketProtocol):
         """
         self._expect_state(ProtocolState.RECEIVING_PACKETS)
 
-        LOG.debug("%d: Starting API request. Requesting packet delay...", id(self))
-        self._ensure_write_transport().write(
-            CMD_DELAY_NEXT_PACKET.encode()
-        )  # Delay packets for 15 seconds
         self._state = ProtocolState.SENT_PACKET_DELAY_REQUEST
-
-        return self._packet_delay_clear_time
+        if self.send_packet_delay:
+            LOG.debug("%d: Starting API request. Requesting packet delay...", id(self))
+            self._ensure_write_transport().write(
+                CMD_DELAY_NEXT_PACKET.encode()
+            )  # Delay packets for 15 seconds
+            return self._packet_delay_clear_time
+        else:
+            return timedelta(seconds=0)
 
     def invoke_api(
         self,

--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -43,6 +43,11 @@ class TestBidirectionalProtocol(unittest.IsolatedAsyncioTestCase):
         self._protocol.begin_api_request()
         self.assertEqual(self._transport.writes, [CMD_DELAY_NEXT_PACKET.encode()])
 
+    def testBeginApiWithoutDelay(self):
+        self._protocol.send_packet_delay = False
+        self._protocol.begin_api_request()
+        self.assertEqual(self._transport.writes, [])
+
     def testSendWithoutBeginFails(self):
         with self.assertRaises(ProtocolStateException):
             self._protocol.invoke_api(TestCall, "request", self._result)


### PR DESCRIPTION
Enable packet delay to be skipped

This PR gives the option of disabling the packet delay, while still leaving it on by default. In my own testing locally, I've seen that we can get away without sending the packet delay request, and that doing so makes GEM API calls almost instantaneous. I'd like to be able to try that out at broader scale, without requiring a new release if it turns out to not work in some cases.
