### PR TITLE
ECM API support

### DIFF
--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum, unique
-from typing import Any, Callable, Generic, Optional, Set, TypeVar, Union
+from typing import Any, Callable, Deque, Generic, List, Optional, Set, TypeVar, Union
 
 from .const import (
     CMD_DELAY_NEXT_PACKET,
@@ -23,6 +24,7 @@ from .packets import (
     ECM_1240,
     MalformedPacketException,
     Packet,
+    PacketFormatType,
 )
 
 LOG = logging.getLogger(__name__)
@@ -74,6 +76,7 @@ class PacketProtocol(asyncio.Protocol):
         self._buffer = bytearray()
         self._queue = queue
         self._transport: Optional[asyncio.BaseTransport] = None
+        self._packet_type: PacketFormatType | None = None
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         LOG.info("%d: Connection opened", id(self))
@@ -189,6 +192,7 @@ class PacketProtocol(asyncio.Protocol):
 
                 packet = BIN48_NET_TIME.parse(self._buffer)
 
+            self._packet_type = packet.packet_format.type
             LOG.debug("%d: Parsed one %s packet.", id(self), packet.packet_format.name)
             del self._buffer[0 : packet.packet_format.size]
             self._queue.put_nowait(PacketReceivedMessage(protocol=self, packet=packet))
@@ -215,8 +219,9 @@ class PacketProtocol(asyncio.Protocol):
 class ProtocolState(Enum):
     RECEIVING_PACKETS = 1  # Receiving packets from the GEM
     SENT_PACKET_DELAY_REQUEST = 2  #  Sent the packet delay request prior to an API request, waiting for any in-flight packets
-    SENT_API_REQUEST = 3  # Sent an API request, waiting for a response
-    RECEIVED_API_RESPONSE = 4  # Received an API response, waiting for end call
+    SENDING_API_REQUEST = 3  # Sending a multi-part request
+    SENT_API_REQUEST = 4  # Sent an API request, waiting for a response
+    RECEIVED_API_RESPONSE = 5  # Received an API response, waiting for end call
 
 
 class ProtocolStateException(Exception):
@@ -248,6 +253,12 @@ T = TypeVar("T")
 R = TypeVar("R")
 
 
+@unique
+class ApiType(Enum):
+    ECM = 1
+    GEM = 2
+
+
 @dataclass
 class ApiCall(Generic[T, R]):
     """
@@ -258,37 +269,66 @@ class ApiCall(Generic[T, R]):
     """
 
     def __init__(
-        self, formatter: Callable[[T], str], parser: Callable[[str], R | None] | None
+        self,
+        gem_formatter: Callable[[T], str],
+        gem_parser: Callable[[str], R | None] | None,
+        ecm_formatter: Callable[[T], List[bytes]] | None,
+        ecm_parser: Callable[[bytes], R | None] | None,
     ) -> None:
         """
         Create a new APICall.
 
-        formatter - a callable that, given a parameter of type T, returns the string to send to the GEM to make the API call
-        parser - a callable that, given a string, parses it into a value of type R.
-                If there is not enough data to parse yet, it should return None.
-                If there is enough data to parse, but it is malformed, it should raise an Exception."""
-        self._formatter = formatter
-        self._parser = parser
+        gem_formatter - a callable that, given a parameter of type T, returns the string to send to the GEM to make the API call
+        gem_parser - a callable that, given a string, parses it into a value of type R.
+                    If there is not enough data to parse yet, it should return None.
+                    If there is enough data to parse, but it is malformed, it should raise an Exception.
+        ecm_formatter - a callable that, given a parameter of type T, returns the series of bytes chunks to send to the ECM to make the API call
+        ecm_parser - a callable that, given a bytes, parses it into a value of type R.
+                    If there is not enough data to parse yet, it should return None.
+                    If there is enough data to parse, but it is malformed, it should raise an Exception.
+        """
+        self._gem_formatter = gem_formatter
+        self._gem_parser = gem_parser
+        self._ecm_formatter = ecm_formatter
+        self._ecm_parser = ecm_parser
 
-    def format(self, arg: T, serial_number: int | None) -> str:
-        result = self._formatter(arg)
-        if serial_number:
-            result = result.replace(
-                ESCAPE_SEQUENCE,
-                f"{TARGET_SERIAL_NUMBER_PREFIX}{serial_number%100000:05}",
-            )
+    def format(
+        self,
+        api_type: ApiType,
+        arg: T,
+        serial_number: int | None,
+    ) -> List[bytes]:
+        if api_type == ApiType.GEM:
+            result = self._gem_formatter(arg)
+            if serial_number:
+                result = result.replace(
+                    ESCAPE_SEQUENCE,
+                    f"{TARGET_SERIAL_NUMBER_PREFIX}{serial_number%100000:05}",
+                )
 
-        return result
-
-    @property
-    def has_parser(self) -> bool:
-        return self._parser is not None
-
-    def parse(self, response: str) -> R | None:
-        if self._parser:
-            return self._parser(response)
+            return [result.encode()]
+        elif api_type == ApiType.ECM:
+            assert self._ecm_formatter
+            result = self._ecm_formatter(arg)
+            return result
         else:
-            return None
+            assert False
+
+    def has_parser(self, api_type: ApiType) -> bool:
+        if api_type == ApiType.GEM:
+            return self._gem_parser is not None
+        elif api_type == ApiType.ECM:
+            return self._ecm_parser is not None
+        else:
+            assert False
+
+    def parse(self, api_type: ApiType, response: bytes) -> R | None:
+        if api_type == ApiType.GEM:
+            return self._gem_parser(response.decode()) if self._gem_parser else None
+        elif api_type == ApiType.ECM:
+            return self._ecm_parser(response) if self._ecm_parser else None
+        else:
+            assert False
 
 
 class BidirectionalProtocol(PacketProtocol):
@@ -306,6 +346,7 @@ class BidirectionalProtocol(PacketProtocol):
         queue: asyncio.Queue[PacketProtocolMessage],
         packet_delay_clear_time: timedelta = PACKET_DELAY_CLEAR_TIME_DEFAULT,
         send_packet_delay: bool = True,
+        api_type: ApiType | None = None,
     ):
         # Ensure that the clear time and the response wait time fit within the 15 second packet delay interval that is requested.
         assert (packet_delay_clear_time + API_RESPONSE_WAIT_TIME) < timedelta(
@@ -319,23 +360,73 @@ class BidirectionalProtocol(PacketProtocol):
         self._state = ProtocolState.RECEIVING_PACKETS
         self._api_call: ApiCall[Any, Any] | None = None
         self._api_result: asyncio.Future[Any] | None = None
+        self._api_type = api_type
+        self._api_requests: Deque[bytes] = deque()
 
     @property
     def packet_delay_clear_time(self) -> timedelta:
         return self._packet_delay_clear_time
 
+    @property
+    def api_type(self) -> ApiType:
+        if self._api_type is None:
+            if (
+                self._packet_type == PacketFormatType.ECM_1220
+                or self._packet_type == PacketFormatType.ECM_1240
+            ):
+                self._api_type = ApiType.ECM
+            elif self._packet_type:
+                self._api_type = ApiType.GEM
+
+        result = self._api_type
+        assert result
+        return result
+
+    @api_type.setter
+    def api_type(self, type: ApiType) -> None:
+        self._api_type = type
+
     def unknown_data_received(self, data: bytes) -> None:
+        if self._state == ProtocolState.SENDING_API_REQUEST:
+            # We're in the middle of an ECM API call, which
+            # has multiple roundtrips to send all the request chunks
+            assert self._api_call
+            if data.startswith(b"\xfc"):
+                # ECM acks each chunk with \xfc
+                if len(self._api_requests) > 0:
+                    self._send_next_api_request_chunk()
+                else:
+                    # No more chunks means that we've now completely sent the request
+                    self._state = ProtocolState.SENT_API_REQUEST
+
+                    if self._api_call.has_parser(self.api_type):
+                        # This API call is expecting a response, and
+                        # the ACK character might be immediately followed
+                        # by response data, so we pull off the ACK character
+                        # and fall through to the rest of the method,
+                        # which then pulls the response from the data
+                        data = data[1:]
+                    else:
+                        # Last ACK of a request with no response
+                        self._set_result(result=None)
+            else:
+                self._set_result(
+                    exception=Exception("Bad response from device: {data}")
+                )
+
         if self._state == ProtocolState.SENT_API_REQUEST:
             assert self._api_call is not None
             self._api_buffer.extend(data)
 
-            response = bytes(self._api_buffer).decode()
-            LOG.debug("%d: Attempting to parse API response: '%s'", id(self), response)
+            response = bytes(self._api_buffer)
+            LOG.debug("%d: Attempting to parse API response: %s", id(self), response)
 
-            result = self._api_call.parse(response)
+            result = self._api_call.parse(self.api_type, response)
             if result:
-                self._set_result(result)
-        else:
+                if self.api_type == ApiType.ECM:
+                    self._ensure_write_transport().write(b"\xfc")
+                self._set_result(result=result)
+        elif self._state == ProtocolState.RECEIVING_PACKETS:
             super().unknown_data_received(data)
 
     def begin_api_request(self) -> timedelta:
@@ -349,7 +440,7 @@ class BidirectionalProtocol(PacketProtocol):
         self._expect_state(ProtocolState.RECEIVING_PACKETS)
 
         self._state = ProtocolState.SENT_PACKET_DELAY_REQUEST
-        if self.send_packet_delay:
+        if self.api_type == ApiType.GEM and self.send_packet_delay:
             LOG.debug("%d: Starting API request. Requesting packet delay...", id(self))
             self._ensure_write_transport().write(
                 CMD_DELAY_NEXT_PACKET.encode()
@@ -373,24 +464,56 @@ class BidirectionalProtocol(PacketProtocol):
         Returns a timedelta. Callers must wait for that amount of time, then call receive_api_response to receive the response.
         """
         self._expect_state(ProtocolState.SENT_PACKET_DELAY_REQUEST)
+        assert len(self._api_requests) == 0
 
         self._api_call = api
         self._api_result = result
-        request = api.format(arg, serial_number)
+        self._api_requests.extend(api.format(self.api_type, arg, serial_number))
 
-        LOG.debug("%d: Sending API request '%s'...", id(self), request)
-        self._ensure_write_transport().write(request.encode())
-        self._state = ProtocolState.SENT_API_REQUEST
-        if not api.has_parser:
-            self._set_result(None)
+        self._send_next_api_request_chunk()
 
-    def _set_result(self, result: Any) -> None:
-        assert self._state == ProtocolState.SENT_API_REQUEST
+    def _send_next_api_request_chunk(self) -> None:
+        assert len(self._api_requests) > 0
+        assert self._api_call
         assert self._api_result
-        self._api_result.set_result(result)
+
+        request = self._api_requests.popleft()
+        LOG.debug("%d: Sending API request %s...", id(self), request)
+        self._ensure_write_transport().write(request)
+        self._state = (
+            ProtocolState.SENT_API_REQUEST
+            if self.api_type == ApiType.GEM
+            else ProtocolState.SENDING_API_REQUEST
+        )
+        if (
+            not self._api_call.has_parser(self.api_type)
+            and self.api_type == ApiType.GEM
+        ):
+            # GEM API calls without a response are just a single send and you're done
+            # (ECM API calls without a response still have multiple request chunks to send,
+            # and even the last chunk is still acked with \xfc, so we don't advance the
+            # state for them here)
+            assert len(self._api_requests) == 0
+            self._set_result(result=None)
+
+    def _set_result(
+        self, result: Any | None = None, exception: Exception | None = None
+    ) -> None:
+        assert (
+            self._state == ProtocolState.SENT_API_REQUEST
+            or self._state == ProtocolState.SENDING_API_REQUEST
+        )
+        assert self._api_result
+        assert not self._api_result.done()
+
+        if exception is None:
+            self._state = ProtocolState.RECEIVED_API_RESPONSE
+            self._api_result.set_result(result)
+        else:
+            assert result is None
+            self._api_result.set_exception(exception)
         self._api_result = None
         self._api_call = None
-        self._state = ProtocolState.RECEIVED_API_RESPONSE
 
     def end_api_request(self) -> None:
         """
@@ -400,11 +523,15 @@ class BidirectionalProtocol(PacketProtocol):
         self._expect_state(
             {
                 ProtocolState.RECEIVED_API_RESPONSE,
+                ProtocolState.SENDING_API_REQUEST,
                 ProtocolState.SENT_API_REQUEST,
                 ProtocolState.SENT_PACKET_DELAY_REQUEST,
             }
         )
         self._api_buffer.clear()
+        self._api_call = None
+        self._api_requests.clear()
+        self._api_result = None
         LOG.debug("%d: Ended API request", id(self))
         self._state = ProtocolState.RECEIVING_PACKETS
 

--- a/tests/gem/test_api.py
+++ b/tests/gem/test_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import List, Optional
 from unittest.async_case import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
@@ -25,6 +25,7 @@ from siobrultech_protocols.gem.api import (
 )
 from siobrultech_protocols.gem.packets import PacketFormatType
 from siobrultech_protocols.gem.protocol import (
+    ApiType,
     BidirectionalProtocol,
     PacketProtocolMessage,
 )
@@ -36,43 +37,39 @@ class TestApi(IsolatedAsyncioTestCase):
         self._queue: asyncio.Queue[PacketProtocolMessage] = asyncio.Queue()
         self._transport = MockTransport()
         self._protocol = BidirectionalProtocol(
-            self._queue, packet_delay_clear_time=timedelta(seconds=0)
+            self._queue,
+            packet_delay_clear_time=timedelta(seconds=0),
+            api_type=ApiType.GEM,
         )
         self._protocol.connection_made(self._transport)
 
-        # Put the protocol into a state where it's ready for commands
-        # and we can see exactly what is sent
-        self._protocol.begin_api_request()
-        self._transport.writes.clear()
-
     async def testApiCallWithoutResponse(self):
-        call = ApiCall(lambda _: "REQUEST", None)
+        call = ApiCall(lambda _: "REQUEST", None, None, None)
 
         await self.assertCall(call, "REQUEST", None, None, None, None)
 
     async def testApiCall(self):
-        call = ApiCall(lambda _: "REQUEST", lambda response: response)
+        call = ApiCall(lambda _: "REQUEST", lambda response: response, None, None)
 
         await self.assertCall(
             call, "REQUEST", None, None, "RESPONSE".encode(), "RESPONSE"
         )
 
     async def testApiCallWithSerialNumber(self):
-        call = ApiCall(lambda _: "^^^REQUEST", lambda response: response)
+        call = ApiCall(lambda _: "^^^REQUEST", lambda response: response, None, None)
 
         await self.assertCall(
             call, "^^^NMB02345REQUEST", None, 1002345, "RESPONSE".encode(), "RESPONSE"
         )
 
     async def testApiCallIgnored(self):
-        call = ApiCall(lambda _: "REQUEST", lambda response: response)
+        call = ApiCall(lambda _: "REQUEST", lambda response: response, None, None)
 
-        self._protocol.end_api_request()
         async with call_api(call, self._protocol, timeout=timedelta(seconds=0)) as f:
             with self.assertRaises(asyncio.exceptions.TimeoutError):
                 await f(None)
 
-    async def testGetSerialNumber(self):
+    async def testGEMGetSerialNumber(self):
         await self.assertCall(
             GET_SERIAL_NUMBER,
             "^^^RQSSRN",
@@ -80,6 +77,16 @@ class TestApi(IsolatedAsyncioTestCase):
             None,
             "1234567\r\n".encode(),
             1234567,
+        )
+
+    async def testECMGetSerialNumber(self):
+        await self.assertECMCall(
+            GET_SERIAL_NUMBER,
+            [b"\xfc", b"SET", b"RCV"],
+            None,
+            None,
+            b"\xa7\x04\xa7\x04\xf4\x03\x01\x0c\x04\x0b\x05\x01\xb2\x90\x00\x00\x00\x00\x8d\x8b\x8c\x8b\xce\x00\xff\xff\xff\xff\x05\x80>\x00m",
+            500434,
         )
 
     async def testSetDateTime(self):
@@ -102,7 +109,7 @@ class TestApi(IsolatedAsyncioTestCase):
             True,
         )
 
-    async def testSetPacketSendInterval(self):
+    async def testGEMSetPacketSendInterval(self):
         await self.assertCall(
             SET_PACKET_SEND_INTERVAL,
             "^^^SYSIVL042",
@@ -110,6 +117,16 @@ class TestApi(IsolatedAsyncioTestCase):
             None,
             "IVL\r\n".encode(),
             True,
+        )
+
+    async def testECMSetPacketSendInterval(self):
+        await self.assertECMCall(
+            SET_PACKET_SEND_INTERVAL,
+            [b"\xfc", b"SET", b"IV2", bytes([42])],
+            42,
+            None,
+            None,
+            None,
         )
 
     async def testSetSecondaryPacketFormat(self):
@@ -131,6 +148,8 @@ class TestApi(IsolatedAsyncioTestCase):
         encoded_response: bytes | None,
         parsed_response: R | None,
     ):
+        self._protocol.begin_api_request()
+        self._transport.writes.clear()  # Ignore the packet delay
         result = asyncio.get_event_loop().create_future()
         self._protocol.invoke_api(call, arg, result, serial_number)
         self.assertEqual(
@@ -147,13 +166,53 @@ class TestApi(IsolatedAsyncioTestCase):
             f"{parsed_response} should be the parsed value returned",
         )
 
+    async def assertECMCall(
+        self,
+        call: ApiCall[T, R],
+        request: List[bytes],
+        arg: T,
+        serial_number: Optional[int],
+        encoded_response: bytes | None,
+        parsed_response: R | None,
+    ):
+        self._protocol.api_type = ApiType.ECM
+        self._transport.writes.clear()
+        self._protocol.begin_api_request()
+        result = asyncio.get_event_loop().create_future()
+        self._protocol.invoke_api(call, arg, result, serial_number)
+        for _ in range(0, len(request)):
+            self._protocol.data_received(b"\xfc")
+        self.assertEqual(
+            self._transport.writes,
+            request,
+            f"{request} should be written to the transport",
+        )
+        if encoded_response is not None:
+            self._transport.writes.clear()
+            self._protocol.data_received(encoded_response)
+        result = await asyncio.wait_for(result, 0)
+        self.assertEqual(
+            result,
+            parsed_response,
+            f"{parsed_response} should be the parsed value returned",
+        )
+        self._protocol.end_api_request()
+        if encoded_response is not None:
+            self.assertEqual(
+                self._transport.writes,
+                [b"\xfc"],
+                f"ECM API calls with a response should be acked by the caller",
+            )
+
 
 class TestContextManager(IsolatedAsyncioTestCase):
     def setUp(self):
         self._queue: asyncio.Queue[PacketProtocolMessage] = asyncio.Queue()
         self._transport = MockTransport()
         self._protocol = BidirectionalProtocol(
-            self._queue, packet_delay_clear_time=timedelta(seconds=0)
+            self._queue,
+            packet_delay_clear_time=timedelta(seconds=0),
+            api_type=ApiType.GEM,
         )
         self._protocol.connection_made(self._transport)
 
@@ -162,14 +221,14 @@ class TestContextManager(IsolatedAsyncioTestCase):
         timedelta(seconds=0),
     )
     async def testApiCall(self):
-        call = ApiCall(lambda _: "REQUEST", lambda response: response)
+        call = ApiCall(lambda _: "REQUEST", lambda response: response, None, None)
         async with call_api(call, self._protocol) as f:
             self.setApiResponse("RESPONSE".encode())
             response = await f(None)
             self.assertEqual(response, "RESPONSE")
 
     async def testTaskCanceled(self):
-        call = ApiCall(lambda _: "REQUEST", lambda response: response)
+        call = ApiCall(lambda _: "REQUEST", lambda response: response, None, None)
         with self.assertRaises(asyncio.CancelledError):
             with patch("asyncio.sleep") as mock_sleep:
                 mock_sleep.side_effect = asyncio.CancelledError
@@ -188,7 +247,9 @@ class TestContextManager(IsolatedAsyncioTestCase):
 class TestApiHelpers(IsolatedAsyncioTestCase):
     def setUp(self):
         self._protocol = BidirectionalProtocol(
-            asyncio.Queue(), packet_delay_clear_time=timedelta(seconds=0)
+            asyncio.Queue(),
+            packet_delay_clear_time=timedelta(seconds=0),
+            api_type=ApiType.GEM,
         )
 
         patcher_API_RESPONSE_WAIT_TIME = patch(

--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -4,6 +4,7 @@ import unittest
 from siobrultech_protocols.gem.const import CMD_DELAY_NEXT_PACKET
 from siobrultech_protocols.gem.protocol import (
     ApiCall,
+    ApiType,
     BidirectionalProtocol,
     ConnectionLostMessage,
     ConnectionMadeMessage,
@@ -15,7 +16,14 @@ from tests.gem.mock_transport import MockTransport
 from tests.gem.packet_test_data import assert_packet, read_packet
 
 TestCall = ApiCall[str, str](
-    formatter=lambda x: x, parser=lambda x: x if x.endswith("\n") else None
+    gem_formatter=lambda x: x,
+    gem_parser=lambda x: x if x.endswith("\n") else None,
+    ecm_formatter=lambda x: [
+        (x + "1").encode(),
+        (x + "2").encode(),
+        (x + "3").encode(),
+    ],
+    ecm_parser=lambda x: x.decode() if x.endswith(b"\n") else None,
 )
 
 
@@ -23,7 +31,7 @@ class TestBidirectionalProtocol(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self._queue: asyncio.Queue[PacketProtocolMessage] = asyncio.Queue()
         self._transport = MockTransport()
-        self._protocol = BidirectionalProtocol(self._queue)
+        self._protocol = BidirectionalProtocol(self._queue, api_type=ApiType.GEM)
         self._protocol.connection_made(self._transport)
         self._result: asyncio.Future[str] = asyncio.get_event_loop().create_future()
         message = self._queue.get_nowait()
@@ -57,6 +65,46 @@ class TestBidirectionalProtocol(unittest.IsolatedAsyncioTestCase):
         self._transport.writes.clear()
         self._protocol.invoke_api(TestCall, "request", self._result)
         self.assertEqual(self._transport.writes, ["request".encode()])
+
+    async def testEcmApiCall(self):
+        self._protocol.api_type = ApiType.ECM
+        self._protocol.begin_api_request()
+        self._protocol.invoke_api(TestCall, "request", self._result)
+        self._protocol.data_received(b"\xfc")
+        self._protocol.data_received(b"\xfc")
+        self._protocol.data_received(b"\xfcRESPONSE\n")
+        response = await self.get_response()
+
+        self.assertEqual(
+            self._transport.writes, [b"request1", b"request2", b"request3", b"\xfc"]
+        )
+        self.assertEqual(response, "RESPONSE\n")
+
+    async def testFailureDuringEcmApiCallDoesNotPreventNextCall(self):
+        self._protocol.api_type = ApiType.ECM
+        self._protocol.begin_api_request()
+        self._protocol.invoke_api(TestCall, "request", self._result)
+        self._protocol.data_received(b"\xfc")
+        self._protocol.data_received(b"X")
+        with self.assertRaises(Exception):
+            await self.get_response()
+        self._protocol.end_api_request()
+        self.assertEqual(self._transport.writes, [b"request1", b"request2"])
+        self._transport.writes.clear()
+
+        self._result = asyncio.get_event_loop().create_future()
+        self._protocol.begin_api_request()
+        self._protocol.invoke_api(TestCall, "request2", self._result)
+        self._protocol.data_received(b"\xfc")
+        self._protocol.data_received(b"\xfc")
+        self._protocol.data_received(b"\xfcRESPONSE\n")
+        response = await self.get_response()
+        self._protocol.end_api_request()
+
+        self.assertEqual(
+            self._transport.writes, [b"request21", b"request22", b"request23", b"\xfc"]
+        )
+        self.assertEqual(response, "RESPONSE\n")
 
     async def testPacketRacingWithApi(self):
         """Tests that the protocol can handle a packet coming in right after it has


### PR DESCRIPTION
ECM API support

The ECM API is rather different from GEM. Instead of a single round-trip per call, each API call involves multiple round-trips. For example, in order to set the packet send interval:

1. PC sends FC (hex)
2. ECM-1240 responds with FC (hex)
3. PC sends three ASCII bytes “S” “E” “T” (must be upper case characters)
4. ECM-1240 responds with FC (hex)
5. PC sends three ASCII bytes “I” “V” “2” (must be upper case characters)
6. ECM-1240 responds with FC (hex)
7. PC sends a single byte chr$(interval value) sends the ascii character representing the interval.
8. ECM-1240 responds with FC (hex)

So that's 4 round-trips for one API call.

This PR updates `ApiCall` to allow separate formatters and parsers to be supplied for GEM and ECM, adds the necessary behaviors in `BidirectionalProtocol`, and supplies implementations for serial number and packet send frequency (the two GEM APIs we support that have ECM equivalents).

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sdwilsh/siobrultech-protocols/pull/126).
* #127
* __->__ #126