### PR TITLE
Fix call_api to use serial number properly

### DIFF
--- a/siobrultech_protocols/gem/api.py
+++ b/siobrultech_protocols/gem/api.py
@@ -32,7 +32,7 @@ async def call_api(
 
     async def send(arg: T) -> R:
         future = asyncio.get_event_loop().create_future()
-        protocol.invoke_api(api, arg, future)
+        protocol.invoke_api(api, arg, future, serial_number)
         return await asyncio.wait_for(future, timeout=timeout.total_seconds())
 
     delay = protocol.begin_api_request()

--- a/tests/gem/test_api.py
+++ b/tests/gem/test_api.py
@@ -227,6 +227,15 @@ class TestContextManager(IsolatedAsyncioTestCase):
             response = await f(None)
             self.assertEqual(response, "RESPONSE")
 
+    async def testApiCallWithSerialNumber(self):
+        call = ApiCall(lambda _: "^^^REQUEST", lambda response: response, None, None)
+        async with call_api(call, self._protocol, serial_number=1234567) as f:
+            self.setApiResponse("RESPONSE".encode())
+            response = await f(None)
+            self.assertEqual(response, "RESPONSE")
+
+        self.assertEqual(self._transport.writes, [b"^^^SYSPDL", b"^^^NMB34567REQUEST"])
+
     async def testTaskCanceled(self):
         call = ApiCall(lambda _: "REQUEST", lambda response: response, None, None)
         with self.assertRaises(asyncio.CancelledError):


### PR DESCRIPTION
Fix call_api to use serial number properly

In the migration from `send_api_request` to `invoke_api`, I accidentally dropped
the serial number. This PR fixes that, and adds a test to enforce it.
