### PR TITLE
Re-add close() method to protocols (Revert #120)

### DIFF
--- a/siobrultech_protocols/gem/protocol.py
+++ b/siobrultech_protocols/gem/protocol.py
@@ -103,6 +103,12 @@ class PacketProtocol(asyncio.Protocol):
         except Exception:
             LOG.exception("%d: Exception while attempting to parse a packet.", id(self))
 
+    def close(self) -> None:
+        """Closes the underlying transport, if any."""
+        if self._transport:
+            self._transport.close()
+        self._transport = None
+
     def _process_buffer(self) -> bool:
         """
         Attempts to process one chunk of data in the buffer.

--- a/tests/gem/test_bidirectional_protocol.py
+++ b/tests/gem/test_bidirectional_protocol.py
@@ -46,6 +46,12 @@ class TestBidirectionalProtocol(unittest.IsolatedAsyncioTestCase):
             assert isinstance(message, ConnectionLostMessage)
             assert message.protocol is self._protocol
             assert message.exc is exc
+        self._protocol.close()  # Close after connection_lost is not required, but at least should not crash
+
+    def testClose(self):
+        self._protocol.close()
+
+        assert self._transport.closed
 
     def testBeginApi(self):
         self._protocol.begin_api_request()

--- a/tests/gem/test_protocol.py
+++ b/tests/gem/test_protocol.py
@@ -39,6 +39,12 @@ class TestPacketAccumulator(unittest.IsolatedAsyncioTestCase):
             assert isinstance(message, ConnectionLostMessage)
             assert message.protocol is self._protocol
             assert message.exc is exc
+        self._protocol.close()  # Close after connection_lost is not required, but at least should not crash
+
+    def testClose(self):
+        self._protocol.close()
+
+        assert self._transport.closed
 
     def test_single_packet(self):
         packet_data = read_packet("BIN32-ABS.bin")


### PR DESCRIPTION
Turns out my reasoning on #120 was incorrect. `asyncio`'s `Server` just keeps track of the listening sockets, not the new sockets that are created for each connection. If we want to be able to close things down properly, we have to keep track of the transports ourselves.