### PR TITLE
Enable formatting packets

### DIFF
--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -283,15 +283,14 @@ class PacketFormat(object):
     def format(self, packet: Packet) -> bytes:
         result = bytearray()
         for key, field in self.fields.items():
-            match key:
-                case "footer":
-                    value = 0xFFFE
-                case "header":
-                    value = 0xFEFF
-                case "code":
-                    value = self.code
-                case _:
-                    value = getattr(packet, key) if hasattr(packet, key) else None
+            if key == "footer":
+                value = 0xFFFE
+            elif key == "header":
+                value = 0xFEFF
+            elif key == "code":
+                value = self.code
+            else:
+                value = getattr(packet, key) if hasattr(packet, key) else None
 
             if value is not None:
                 field.write(value, result)

--- a/tests/gem/test_fields.py
+++ b/tests/gem/test_fields.py
@@ -66,6 +66,14 @@ class TestFieldParsing(unittest.TestCase):
             ),
         )
 
+    def testFloatingPointFieldReadDiv100(self):
+        self.assertEqual(
+            1.16,
+            FloatingPointField(2, ByteOrder.HiToLo, Sign.Unsigned, 100.0).read(
+                b"\x02\x00\x74", 1
+            ),
+        )
+
     def testDateTimeFieldRead(self):
         self.assertEqual(
             datetime(2020, 1, 1, 0, 0, 0),
@@ -95,3 +103,76 @@ class TestFieldParsing(unittest.TestCase):
                 b"\x05\x00\x01\x00\x02\x00\x03\x00\x04", 1
             ),
         )
+
+
+class TestFieldFormatting(unittest.TestCase):
+    def setUp(self):
+        self._buffer = bytearray()
+
+    def testByteFieldWrite(self):
+        ByteField().write(ord("c"), self._buffer)
+        self.assertEqual(b"c", self._buffer)
+
+    def testBytesFieldWrite(self):
+        BytesField(4).write([ord(char) for char in "cdef"], self._buffer)
+        self.assertEqual(b"cdef", self._buffer)
+
+    def testNumericFieldHiToLoWrite(self):
+        NumericField(2, ByteOrder.HiToLo, Sign.Signed).write(1, self._buffer)
+        self.assertEqual(b"\x00\x01", self._buffer)
+
+    def testNumericFieldHiToLoSignedWrite(self):
+        NumericField(2, ByteOrder.HiToLo, Sign.Signed).write(-1, self._buffer)
+        self.assertEqual(b"\x80\x01", self._buffer)
+
+    def testNumericFieldLoToHiWrite(self):
+        NumericField(2, ByteOrder.LoToHi, Sign.Signed).write(256, self._buffer)
+        self.assertEqual(b"\x00\x01", self._buffer)
+
+    def testNumericFieldLoToHiSignedWrite(self):
+        NumericField(2, ByteOrder.LoToHi, Sign.Signed).write(-256, self._buffer)
+        self.assertEqual(b"\x00\x81", self._buffer)
+
+    def testNumericFieldUnsignedMax(self):
+        field = NumericField(2, ByteOrder.HiToLo, Sign.Unsigned)
+        field.write(field.max, self._buffer)
+        self.assertEqual(b"\xff\xff", self._buffer)
+
+    def testNumericFieldSignedMax(self):
+        field = NumericField(2, ByteOrder.HiToLo, Sign.Signed)
+        field.write(field.max, self._buffer)
+        self.assertEqual(b"\x7f\xff", self._buffer)
+
+    def testFloatingPointFieldWrite(self):
+        FloatingPointField(2, ByteOrder.HiToLo, Sign.Unsigned, 2.0).write(
+            0.5, self._buffer
+        )
+        self.assertEqual(b"\x00\x01", self._buffer)
+
+    def testFloatingPointFieldWriteDiv100(self):
+        FloatingPointField(2, ByteOrder.HiToLo, Sign.Unsigned, 100.0).write(
+            1.16, self._buffer
+        )
+        self.assertEqual(b"\x00\x74", self._buffer)
+
+    def testDateTimeFieldWrite(self):
+        DateTimeField().write(datetime(2020, 1, 1, 0, 0, 0), self._buffer)
+        self.assertEqual(b"\x14\x01\x01\x00\x00\x00", self._buffer)
+
+    def testArrayFieldWrite(self):
+        ArrayField(4, NumericField(2, ByteOrder.HiToLo, Sign.Unsigned)).write(
+            [1, 2, 3, 4], self._buffer
+        )
+        self.assertEqual(b"\x00\x01\x00\x02\x00\x03\x00\x04", self._buffer)
+
+    def testNumericArrayFieldWrite(self):
+        NumericArrayField(4, 2, ByteOrder.HiToLo, Sign.Unsigned).write(
+            [1, 2, 3, 4], self._buffer
+        )
+        self.assertEqual(b"\x00\x01\x00\x02\x00\x03\x00\x04", self._buffer)
+
+    def testFloatingPointArrayFieldWrite(self):
+        FloatingPointArrayField(4, 2, ByteOrder.HiToLo, Sign.Unsigned, 2.0).write(
+            [0.5, 1.0, 1.5, 2.0], self._buffer
+        )
+        self.assertEqual(b"\x00\x01\x00\x02\x00\x03\x00\x04", self._buffer)

--- a/tests/gem/test_packets.py
+++ b/tests/gem/test_packets.py
@@ -258,6 +258,11 @@ def check_packet(packet_file_name: str, packet_format: packets.PacketFormat):
 
     assert_packet(packet_file_name, packet)
 
+    raw_data = packet_format.format(packet)
+    reparsed_packet = packet_format.parse(raw_data)
+
+    assert_packet(packet_file_name, reparsed_packet)
+
 
 def parse_packet(packet_file_name: str, packet_format: packets.PacketFormat):
     return packet_format.parse(read_packet(packet_file_name))


### PR DESCRIPTION
While debugging an issue, I wanted to create a fake monitor that would send packets of my own construction. To do that, I enabled Field and Packet to format values as well as parse them. 