### PR TITLE
Fix Lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: earthly/actions-setup@v1.0.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # renovate: datasource=docker depName=earthly/earthly
+          version: "v0.7.22"
       - uses: actions/checkout@v4
       - name: Earthly Lint
-        run: ./earthly.sh +lint
+        env:
+          EARTHLY_CI: true
+        run: earthly +lint

--- a/Earthfile
+++ b/Earthfile
@@ -26,12 +26,15 @@ black-validate:
     COPY --dir tests .
     RUN black . --check --diff --color
 
-pyright-validate:
-    # renovate: datasource=pypi depName=pyright
-    ARG PYRIGHT_VERSION=1.1.339
+pyright-image:
     FROM +python-dev-requirements
+    RUN nodeenv /.cache/nodeenv
+    ENV PYRIGHT_PYTHON_ENV_DIR=/.cache/nodeenv
     WORKDIR /usr/src/app
-    RUN pip install --no-cache-dir pyright==$PYRIGHT_VERSION
+
+pyright-validate:
+    FROM +pyright-image
+    WORKDIR /usr/src/app
     COPY pyproject.toml .
     COPY --dir scripts .
     COPY --dir siobrultech_protocols .

--- a/Earthfile
+++ b/Earthfile
@@ -21,9 +21,9 @@ python-dev-requirements:
 black-validate:
     FROM +python-dev-requirements
     WORKDIR /usr/src/app
-    COPY scripts .
-    COPY siobrultech_protocols .
-    COPY tests .
+    COPY --dir scripts .
+    COPY --dir siobrultech_protocols .
+    COPY --dir tests .
     RUN black . --check --diff --color
 
 pyright-validate:
@@ -33,9 +33,9 @@ pyright-validate:
     WORKDIR /usr/src/app
     RUN pip install --no-cache-dir pyright==$PYRIGHT_VERSION
     COPY pyproject.toml .
-    COPY scripts .
-    COPY siobrultech_protocols .
-    COPY tests .
+    COPY --dir scripts .
+    COPY --dir siobrultech_protocols .
+    COPY --dir tests .
     RUN pyright
 
 renovate-validate:
@@ -50,9 +50,9 @@ ruff-validate:
     FROM +python-dev-requirements
     WORKDIR /usr/src/app
     COPY pyproject.toml .
-    COPY scripts .
-    COPY siobrultech_protocols .
-    COPY tests .
+    COPY --dir scripts .
+    COPY --dir siobrultech_protocols .
+    COPY --dir tests .
     RUN ruff check . --diff
 
 lint:

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,15 @@
   },
   "regexManagers": [
     {
+      "customType": "regex",
+      "fileMatch": [
+        "^\\.github/workflows/.*\\.yml$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s+(?:[a-z\\-_]+)?version:\\s+\"(?<currentValue>.*?)\""
+      ]
+    },
+    {
       "fileMatch": [
         "^Earthfile$"
       ],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black==23.11.0
+pyright==1.1.339
 pytest==7.4.3
 pytest-asyncio==0.21.1
 pyyaml==6.0.1

--- a/siobrultech_protocols/gem/packets.py
+++ b/siobrultech_protocols/gem/packets.py
@@ -40,7 +40,7 @@ class Packet(object):
         serial_number: int,
         seconds: int,
         pulse_counts: Optional[List[int]] = None,
-        temperatures: Optional[List[float | None]] = None,
+        temperatures: Optional[List[Optional[float]]] = None,
         polarized_watt_seconds: Optional[List[int]] = None,
         currents: Optional[List[float]] = None,
         time_stamp: Optional[datetime] = None,

--- a/tests/gem/test_api.py
+++ b/tests/gem/test_api.py
@@ -44,22 +44,33 @@ class TestApi(IsolatedAsyncioTestCase):
         self._protocol.connection_made(self._transport)
 
     async def testApiCallWithoutResponse(self):
-        call = ApiCall(lambda _: "REQUEST", None, None, None)
-
-        await self.assertCall(call, "REQUEST", None, None, None, None)
+        await self.assertCall(
+            ApiCall(lambda _: "REQUEST", None, None, None),
+            "REQUEST",
+            None,
+            None,
+            None,
+            None,
+        )
 
     async def testApiCall(self):
-        call = ApiCall(lambda _: "REQUEST", lambda response: response, None, None)
-
         await self.assertCall(
-            call, "REQUEST", None, None, "RESPONSE".encode(), "RESPONSE"
+            ApiCall(lambda _: "REQUEST", lambda response: response, None, None),
+            "REQUEST",
+            None,
+            None,
+            "RESPONSE".encode(),
+            "RESPONSE",
         )
 
     async def testApiCallWithSerialNumber(self):
-        call = ApiCall(lambda _: "^^^REQUEST", lambda response: response, None, None)
-
         await self.assertCall(
-            call, "^^^NMB02345REQUEST", None, 1002345, "RESPONSE".encode(), "RESPONSE"
+            ApiCall(lambda _: "^^^REQUEST", lambda response: response, None, None),
+            "^^^NMB02345REQUEST",
+            None,
+            1002345,
+            "RESPONSE".encode(),
+            "RESPONSE",
         )
 
     async def testApiCallIgnored(self):

--- a/tests/gem/test_fields.py
+++ b/tests/gem/test_fields.py
@@ -114,7 +114,7 @@ class TestFieldFormatting(unittest.TestCase):
         self.assertEqual(b"c", self._buffer)
 
     def testBytesFieldWrite(self):
-        BytesField(4).write([ord(char) for char in "cdef"], self._buffer)
+        BytesField(4).write(b"cdef", self._buffer)
         self.assertEqual(b"cdef", self._buffer)
 
     def testNumericFieldHiToLoWrite(self):

--- a/tests/gem/test_packets.py
+++ b/tests/gem/test_packets.py
@@ -13,7 +13,7 @@ packet_maker = functools.partial(
     serial_number=123456,
     seconds=0,
     pulse_counts=[0] * packets.GEMPacketFormat.NUM_PULSE_COUNTERS,
-    temperatures=[0] * packets.GEMPacketFormat.NUM_TEMPERATURE_SENSORS,
+    temperatures=list([0.0] * packets.GEMPacketFormat.NUM_TEMPERATURE_SENSORS),
     aux=None,
 )
 


### PR DESCRIPTION
I broke linters in the past when I moved to Earthly.  Luckily, only pyright was sad, but it took a little while to figure out how to fix all the cases.

This change does a few things that are largely related:
1) Fix lint to it actually runs (need to pass `--dir` to `COPY`)
2) Fixup the linter issues
3) Make it so iterating on pyright issues with Earthly is much, much faster
4) Make Earthly run faster in CI too